### PR TITLE
RIA-5487-Record-the-Decision-Event/State

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -9,6 +9,8 @@ public enum Event {
     SUBMIT_APPLICATION("submitApplication"),
     END_APPLICATION("endApplication"),
     UPLOAD_BAIL_SUMMARY("uploadBailSummary"),
+    RECORD_THE_DECISION("recordTheDecision"),
+
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
@@ -8,6 +8,7 @@ public enum State {
     APPLICATION_ENDED("applicationEnded"),
     APPLICATION_SUBMITTED("applicationSubmitted"),
     BAIL_SUMMARY_UPLOADED("bailSummaryUploaded"),
+    RECORD_THE_DECISION("recordTheDecision"),
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -11,6 +11,7 @@ public class EventTest {
         assertEquals("startApplication", Event.START_APPLICATION.toString());
         assertEquals("endApplication", Event.END_APPLICATION.toString());
         assertEquals("submitApplication", Event.SUBMIT_APPLICATION.toString());
+        assertEquals("uploadBailSummary", Event.UPLOAD_BAIL_SUMMARY.toString());
         assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -11,12 +11,12 @@ public class EventTest {
         assertEquals("startApplication", Event.START_APPLICATION.toString());
         assertEquals("endApplication", Event.END_APPLICATION.toString());
         assertEquals("submitApplication", Event.SUBMIT_APPLICATION.toString());
-        assertEquals("uploadBailSummary", Event.UPLOAD_BAIL_SUMMARY.toString());
+        assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(5, Event.values().length);
+        assertEquals(6, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
@@ -12,12 +12,14 @@ public class StateTest {
         assertEquals("applicationEnded", State.APPLICATION_ENDED.toString());
         assertEquals("applicationSubmitted", State.APPLICATION_SUBMITTED.toString());
         assertEquals("bailSummaryUploaded", State.BAIL_SUMMARY_UPLOADED.toString());
+        assertEquals("uploadBailSummary", Event.UPLOAD_BAIL_SUMMARY.toString());
+        assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
         assertEquals("unknown", State.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(5, State.values().length);
+        assertEquals(6, State.values().length);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5487


### Change description ###
As an admin user,

I want to select the Record the decision event,

So that I can record the decision.

Acceptance Criteria :

 Record the decision event can be triggered after upload bail summary only by admin.

 Record the decision event should be shown in the list as attached.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
