### PR TITLE
RIA-5490 Bail transfer field pre-population 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -266,7 +266,9 @@ public enum BailCaseFieldDefinition {
     CONDITION_REPORTING(
         "conditionsForBailReporting", new TypeReference<String>(){}),
     CONDITION_ELECTRONIC_MONITORING(
-        "conditionsForBailElectronicMonitoring",  new TypeReference<String>(){});
+        "conditionsForBailElectronicMonitoring",  new TypeReference<String>(){}),
+    BAIL_TRANSFER_DIRECTIONS(
+        "bailTransferDirections", new TypeReference<String>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppender.java
@@ -80,12 +80,18 @@ public class RecordDecisionAppender implements PreSubmitCallbackHandler<BailCase
             + " will commence and the applicant is to be released subject to the other conditions of this grant"
             + " of bail. In such an event the Secretary of State will make arrangements for the fitting of the"
             + " electronic monitoring device post release.";
+        String bailTransferDirections =
+            "The Tribunal directs that future management including any application for variation shall be exercised by"
+            + " the Secretary of State pursuant by paragraph 6(3) of Schedule 10 to the Immigration Act 2016.\n"
+            + "Please note: Where the Tribunal directs that bail management shall be transferred to the Secretary"
+            + " of State (including any hearing to determine liability for payment of a financial condition).";
 
         bailCase.write(BailCaseFieldDefinition.CONDITION_APPEARANCE, conditionAppearance);
         bailCase.write(BailCaseFieldDefinition.CONDITION_ACTIVITIES, conditionActivities);
         bailCase.write(BailCaseFieldDefinition.CONDITION_RESIDENCE, conditionResidence);
         bailCase.write(BailCaseFieldDefinition.CONDITION_REPORTING, conditionReporting);
         bailCase.write(BailCaseFieldDefinition.CONDITION_ELECTRONIC_MONITORING, conditionElectronicMonitoring);
+        bailCase.write(BailCaseFieldDefinition.BAIL_TRANSFER_DIRECTIONS, bailTransferDirections);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppender.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
-import static java.util.Objects.requireNonNull;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
@@ -11,6 +9,8 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @Component

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppenderTest.java
@@ -19,7 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.BAIL_TRANSFER_DIRECTIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_ACTIVITIES;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_APPEARANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_ELECTRONIC_MONITORING;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_REPORTING;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_RESIDENCE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/RecordDecisionAppenderTest.java
@@ -19,11 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_APPEARANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_ACTIVITIES;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_RESIDENCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_REPORTING;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CONDITION_ELECTRONIC_MONITORING;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,6 +99,11 @@ class RecordDecisionAppenderTest {
             + " will commence and the applicant is to be released subject to the other conditions of this grant"
             + " of bail. In such an event the Secretary of State will make arrangements for the fitting of the"
             + " electronic monitoring device post release.";
+        String bailTransferDirections =
+            "The Tribunal directs that future management including any application for variation shall be exercised by"
+            + " the Secretary of State pursuant by paragraph 6(3) of Schedule 10 to the Immigration Act 2016.\n"
+            + "Please note: Where the Tribunal directs that bail management shall be transferred to the Secretary"
+            + " of State (including any hearing to determine liability for payment of a financial condition).";
 
         verify(bailCase, times(1)).write(CONDITION_APPEARANCE, conditionAppearance);
         verify(bailCase, times(1)).write(CONDITION_ACTIVITIES, conditionActivities);
@@ -110,6 +111,8 @@ class RecordDecisionAppenderTest {
         verify(bailCase, times(1)).write(CONDITION_REPORTING, conditionReporting);
         verify(bailCase, times(1)).write(CONDITION_ELECTRONIC_MONITORING,
                                          conditionElectronicMonitoring);
+        verify(bailCase, times(1)).write(BAIL_TRANSFER_DIRECTIONS, bailTransferDirections);
+
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-5490

### Change description ###

Added a field into RecordDecisionAppender to pre-populate on bail transfer screen. Plus in the unit test.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
