### PR TITLE
RIA-5519 Add UploadSignedDecisionNotice event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -5,6 +5,7 @@ import java.util.List;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.NationalityFieldValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 
@@ -270,7 +271,11 @@ public enum BailCaseFieldDefinition {
     BAIL_TRANSFER_DIRECTIONS(
         "bailTransferDirections", new TypeReference<String>(){}),
     SECRETARY_OF_STATE_REFUSAL_REASONS(
-        "secretaryOfStateRefusalReasons", new TypeReference<String>(){});
+        "secretaryOfStateRefusalReasons", new TypeReference<String>(){}),
+    UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT(
+        "uploadSignedDecisionNoticeDocument", new TypeReference<Document>(){}),
+    SIGNED_DECISION_NOTICE_METADATA(
+        "signedDecisionNoticeMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
@@ -8,6 +8,7 @@ public enum DocumentTag {
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs"),
     APPLICATION_SUBMISSION("applicationSubmission"),
     BAIL_SUMMARY("uploadBailSummary"),
+    SIGNED_DECISION_NOTICE("signedDecisionNotice"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -10,6 +10,7 @@ public enum Event {
     END_APPLICATION("endApplication"),
     UPLOAD_BAIL_SUMMARY("uploadBailSummary"),
     RECORD_THE_DECISION("recordTheDecision"),
+    UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
@@ -11,6 +11,7 @@ public enum State {
     APPLICATION_SUBMITTED("applicationSubmitted"),
     BAIL_SUMMARY_UPLOADED("bailSummaryUploaded"),
     RECORD_THE_DECISION("recordTheDecision"),
+    SIGNED_DECISION_NOTICE_UPLOADED("signedDecisionNoticeUploaded"),
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SignedDecisionNoticeUploadedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SignedDecisionNoticeUploadedConfirmation.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class SignedDecisionNoticeUploadedConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(Callback<BailCase> callback) {
+        return (callback.getEvent() == Event.UPLOAD_SIGNED_DECISION_NOTICE);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationBody(
+            "### What happens next\n\n"
+            + "The signed decision notice is available to view in the [documents tab](/cases/case-details/"
+            + callback.getCaseDetails().getId()
+            + "#Documents)."
+        );
+
+        postSubmitResponse.setConfirmationHeader("# You uploaded the signed decision notice");
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SIGNED_DECISION_NOTICE_METADATA;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithDescription;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentReceiver;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentsAppender;
+
+@Component
+public class UploadSignedDecisionNoticeHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    private final DocumentReceiver documentReceiver;
+    private final DocumentsAppender documentsAppender;
+
+    public UploadSignedDecisionNoticeHandler(
+        DocumentReceiver documentReceiver,
+        DocumentsAppender documentsAppender
+    ) {
+        this.documentReceiver = documentReceiver;
+        this.documentsAppender = documentsAppender;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == Event.UPLOAD_SIGNED_DECISION_NOTICE;
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Document maybeSignedDecisionNotice = bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)
+            .orElseThrow(() -> new IllegalStateException("signed decision notice is not present"));
+
+        List<DocumentWithMetadata> signedDecisionNotice = new ArrayList<>();
+        documentReceiver.tryReceive(
+                new DocumentWithDescription(maybeSignedDecisionNotice, ""), DocumentTag.SIGNED_DECISION_NOTICE)
+            .ifPresent(signedDecisionNotice::add);
+
+        bailCase.clear(SIGNED_DECISION_NOTICE_METADATA);
+
+        List<IdValue<DocumentWithMetadata>> newSignedDecisionNotice =
+            documentsAppender.append(new ArrayList<>(), signedDecisionNotice);
+
+        bailCase.write(SIGNED_DECISION_NOTICE_METADATA, newSignedDecisionNotice);
+
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
@@ -12,13 +12,14 @@ public class DocumentTagTest {
         assertEquals("uploadTheBailEvidenceDocs", DocumentTag.BAIL_EVIDENCE.toString());
         assertEquals("applicationSubmission", DocumentTag.APPLICATION_SUBMISSION.toString());
         assertEquals("uploadBailSummary", DocumentTag.BAIL_SUMMARY.toString());
+        assertEquals("signedDecisionNotice", DocumentTag.SIGNED_DECISION_NOTICE.toString());
         assertEquals("", DocumentTag.NONE.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(4, DocumentTag.values().length);
+        assertEquals(5, DocumentTag.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -13,11 +13,12 @@ public class EventTest {
         assertEquals("submitApplication", Event.SUBMIT_APPLICATION.toString());
         assertEquals("uploadBailSummary", Event.UPLOAD_BAIL_SUMMARY.toString());
         assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
+        assertEquals("uploadSignedDecisionNotice", Event.UPLOAD_SIGNED_DECISION_NOTICE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(6, Event.values().length);
+        assertEquals(7, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
@@ -14,14 +14,13 @@ public class StateTest {
         assertEquals("applicationEnded", State.APPLICATION_ENDED.toString());
         assertEquals("applicationSubmitted", State.APPLICATION_SUBMITTED.toString());
         assertEquals("bailSummaryUploaded", State.BAIL_SUMMARY_UPLOADED.toString());
-        assertEquals("uploadBailSummary", Event.UPLOAD_BAIL_SUMMARY.toString());
-        assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
+        assertEquals("signedDecisionNoticeUploaded", State.SIGNED_DECISION_NOTICE_UPLOADED.toString());
         assertEquals("unknown", State.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(8, State.values().length);
+        assertEquals(9, State.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
@@ -14,6 +14,7 @@ public class StateTest {
         assertEquals("applicationEnded", State.APPLICATION_ENDED.toString());
         assertEquals("applicationSubmitted", State.APPLICATION_SUBMITTED.toString());
         assertEquals("bailSummaryUploaded", State.BAIL_SUMMARY_UPLOADED.toString());
+        assertEquals("recordTheDecision", State.RECORD_THE_DECISION.toString());
         assertEquals("signedDecisionNoticeUploaded", State.SIGNED_DECISION_NOTICE_UPLOADED.toString());
         assertEquals("unknown", State.UNKNOWN.toString());
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SignedDecisionNoticeUploadedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SignedDecisionNoticeUploadedConfirmationTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SignedDecisionNoticeUploadedConfirmationTest {
+
+    @Mock private Callback<BailCase> callback;
+
+    @Mock private CaseDetails<BailCase> caseDetails;
+    private SignedDecisionNoticeUploadedConfirmation signedDecisionNoticeUploadedConfirmation;
+
+    @BeforeEach
+    public void setUp() {
+        signedDecisionNoticeUploadedConfirmation = new SignedDecisionNoticeUploadedConfirmation();
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_SIGNED_DECISION_NOTICE);
+    }
+
+    @Test
+    void should_set_header_body() {
+        long caseId = 1234L;
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getId()).thenReturn(caseId);
+        PostSubmitCallbackResponse response = signedDecisionNoticeUploadedConfirmation.handle(callback);
+
+        assertNotNull(response.getConfirmationBody(), "Confirmation Body is null");
+        assertThat(response.getConfirmationBody().get()).contains("### What happens next");
+
+        assertNotNull(response.getConfirmationHeader(), "Confirmation Header is null");
+        assertThat(response.getConfirmationHeader().get()).isEqualTo("# You uploaded the signed decision notice");
+    }
+
+    @Test
+    void should_not_allow_null_args() {
+        assertThatThrownBy(() -> signedDecisionNoticeUploadedConfirmation.handle(null))
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_handle_invalid_callback() {
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION); //Invalid event for this handler
+
+        assertThatThrownBy(() -> signedDecisionNoticeUploadedConfirmation.handle(callback)).isExactlyInstanceOf(
+            IllegalStateException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -76,7 +76,7 @@ public class UploadSignedDecisionNoticeHandlerTest {
     }
 
     @Test
-    void should_add_new_document_to_the_case_when_no_documents_exist() {
+    void should_add_new_document_to_the_case() {
 
         when(bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)).thenReturn(
             Optional.of(signedDecisionNotice1));

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -1,0 +1,147 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SIGNED_DECISION_NOTICE_METADATA;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithDescription;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentReceiver;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentsAppender;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class UploadSignedDecisionNoticeHandlerTest {
+
+    @Mock
+    private DocumentReceiver documentReceiver;
+    @Mock
+    private DocumentsAppender documentsAppender;
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    @Mock
+    private Document signedDecisionNotice1;
+    @Mock
+    private DocumentWithMetadata signedDecisionNoticeMetadata1;
+    @Mock
+    private List<IdValue<DocumentWithMetadata>> newSignedDecisionNotice;
+
+    @Captor
+    private ArgumentCaptor<List<IdValue<DocumentWithMetadata>>> existingDecisionNoticeDocumentsCaptor;
+
+    private UploadSignedDecisionNoticeHandler uploadSignedDecisionNoticeHandler;
+
+    @BeforeEach
+    public void setUp() {
+        uploadSignedDecisionNoticeHandler =
+            new UploadSignedDecisionNoticeHandler(
+                documentReceiver,
+                documentsAppender
+            );
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_SIGNED_DECISION_NOTICE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+    }
+
+    @Test
+    void should_add_new_document_to_the_case_when_no_documents_exist() {
+
+        when(bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)).thenReturn(
+            Optional.of(signedDecisionNotice1));
+
+        when(documentReceiver.tryReceive(new DocumentWithDescription(signedDecisionNotice1, ""),
+                                         DocumentTag.SIGNED_DECISION_NOTICE))
+            .thenReturn(Optional.of(signedDecisionNoticeMetadata1));
+
+        when(documentsAppender.append(any(List.class), eq(List.of(signedDecisionNoticeMetadata1))))
+            .thenReturn(newSignedDecisionNotice);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(bailCase, callbackResponse.getData());
+
+        verify(bailCase, times(1)).read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class);
+
+        verify(documentReceiver, times(1)).tryReceive(
+            new DocumentWithDescription(signedDecisionNotice1, ""),
+            DocumentTag.SIGNED_DECISION_NOTICE);
+
+        verify(documentsAppender, times(1))
+            .append(existingDecisionNoticeDocumentsCaptor.capture(), eq(List.of(signedDecisionNoticeMetadata1)));
+
+        List<IdValue<DocumentWithMetadata>> actualExistingDecisionNoticeDocuments =
+            existingDecisionNoticeDocumentsCaptor
+                .getAllValues()
+                .get(0);
+
+        assertEquals(0, actualExistingDecisionNoticeDocuments.size());
+
+        verify(bailCase, times(1)).clear(SIGNED_DECISION_NOTICE_METADATA);
+
+        verify(bailCase, times(1)).write(SIGNED_DECISION_NOTICE_METADATA, newSignedDecisionNotice);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(
+            () -> uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> uploadSignedDecisionNoticeHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+            () -> uploadSignedDecisionNoticeHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadSignedDecisionNoticeHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5519](https://tools.hmcts.net/jira/browse/RIA-5519)


### Change description ###
Addition of all the fundamental changes to set up a new event (Upload Signed Decision Notice), i.e.:
- addition to State, Event, DocumentTag, BailCaseFieldDefinitions
- creation of a pre-event handler and a post-event handler
- amendment of existing tests and addition of new ones for the new classes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
