### PR TITLE
RIA-5532: Added intermediate state for uploadSignedDecisionNotice

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.NationalityFieldValue;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
@@ -19,15 +18,15 @@ public enum BailCaseFieldDefinition {
     IS_HOME_OFFICE(
         "isHomeOffice", new TypeReference<YesOrNo>() {}),
     CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE(
-        "currentCaseStateVisibleToLegalRepresentative", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToLegalRepresentative", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_JUDGE(
-        "currentCaseStateVisibleToJudge", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToJudge", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER(
-        "currentCaseStateVisibleToAdminOfficer", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToAdminOfficer", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE(
-        "currentCaseStateVisibleToHomeOffice", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToHomeOffice", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS(
-        "currentCaseStateVisibleToAllUsers", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToAllUsers", new TypeReference<String>(){}),
     APPLICANT_GIVEN_NAMES(
         "applicantGivenNames", new TypeReference<String>() {}),
     APPLICANT_FAMILY_NAME(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateState.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateState.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * These enums are the intermediate states which are not being displayed as separate states.
+ * For ex: From Record_Decision event case can go from decided or ConditionalBail on UI but
+ * from UPLOAD_SIGNED_DECISION_NOTICE the state will not change. But we need to set the
+ * intermediate state in order to show/hide the fields in the tab.
+ */
+public enum IntermediateState {
+
+    SIGNED_DECISION_NOTICE_UPLOADED("signedDecisionNoticeUploaded"),
+    @JsonEnumDefaultValue
+    UNKNOWN("unknown");
+
+    @JsonValue
+    private final String id;
+
+    IntermediateState(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
@@ -10,7 +10,6 @@ public enum State {
     APPLICATION_ENDED("applicationEnded"),
     APPLICATION_SUBMITTED("applicationSubmitted"),
     BAIL_SUMMARY_UPLOADED("bailSummaryUploaded"),
-    SIGNED_DECISION_NOTICE_UPLOADED("signedDecisionNoticeUploaded"),
     DECISION_DECIDED("decisionDecided"),
     DECISION_CONDITIONAL_BAIL("decisionConditionalBail"),
     @JsonEnumDefaultValue

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateStateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateStateTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class IntermediateStateTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("signedDecisionNoticeUploaded", IntermediateState.SIGNED_DECISION_NOTICE_UPLOADED.toString());
+        assertEquals("unknown", State.UNKNOWN.toString());
+    }
+
+    @Test
+    void fail_if_changes_needed_after_modifying_class() {
+        assertEquals(2, IntermediateState.values().length);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
@@ -14,7 +14,6 @@ public class StateTest {
         assertEquals("applicationEnded", State.APPLICATION_ENDED.toString());
         assertEquals("applicationSubmitted", State.APPLICATION_SUBMITTED.toString());
         assertEquals("bailSummaryUploaded", State.BAIL_SUMMARY_UPLOADED.toString());
-        assertEquals("signedDecisionNoticeUploaded", State.SIGNED_DECISION_NOTICE_UPLOADED.toString());
         assertEquals("decisionDecided", State.DECISION_DECIDED.toString());
         assertEquals("decisionConditionalBail", State.DECISION_CONDITIONAL_BAIL.toString());
         assertEquals("unknown", State.UNKNOWN.toString());
@@ -22,7 +21,7 @@ public class StateTest {
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(10, State.values().length);
+        assertEquals(9, State.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
@@ -46,10 +46,11 @@ class CurrentCaseStateUpdaterTest {
         new CurrentCaseStateUpdater();
 
     @Test
-    void should_set_case_building_ready_for_submission_flag_to_yes() {
+    void should_set_variables_to_appropriate_states() {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPLICATION);
 
         for (State state : State.values()) {
 
@@ -62,10 +63,10 @@ class CurrentCaseStateUpdaterTest {
             assertNotNull(callbackResponse);
             assertEquals(bailCase, callbackResponse.getData());
 
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state);
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state.toString());
             reset(bailCase);
         }
     }
@@ -123,22 +124,24 @@ class CurrentCaseStateUpdaterTest {
 
     @Test
     void should_update_state_to_conditionalGrant_based_on_decision_type() {
+        State state = DECISION_CONDITIONAL_BAIL;
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(caseDetails.getState()).thenReturn(state);
         when(bailCase.read(RECORD_DECISION_TYPE, String.class)).thenReturn(Optional.of("conditionalGrant"));
+        when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
 
         PreSubmitCallbackResponse<BailCase> response = currentCaseStateUpdater
             .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
-        State state = DECISION_CONDITIONAL_BAIL;
         assertNotNull(response);
         assertEquals(bailCase, response.getData());
 
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS, state);
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS, state.toString());
         reset(bailCase);
     }
 }


### PR DESCRIPTION
- Updated current state to new intermediate state for Event.UPLOAD_SIGNED_DECISION_NOTICE.
- Changed the currentCaseStateVisibleTo* variables type to String from State.

