### PR TITLE
RIA-5214 Add END_APPLICATION to events to handle for notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -45,7 +45,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<BailCas
         List<Event> eventsToHandle = Lists.newArrayList(
             Event.SUBMIT_APPLICATION,
             Event.UPLOAD_BAIL_SUMMARY,
-            Event.UPLOAD_SIGNED_DECISION_NOTICE
+            Event.UPLOAD_SIGNED_DECISION_NOTICE,
+            Event.END_APPLICATION
         );
         return eventsToHandle;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -104,7 +104,8 @@ class SendNotificationHandlerTest {
                     Arrays.asList(
                         Event.SUBMIT_APPLICATION,
                         Event.UPLOAD_BAIL_SUMMARY,
-                        Event.UPLOAD_SIGNED_DECISION_NOTICE
+                        Event.UPLOAD_SIGNED_DECISION_NOTICE,
+                        Event.END_APPLICATION
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5214](https://tools.hmcts.net/jira/browse/RIA-5214)


### Change description ###
Allow END_APPLICATION to be among the events for which notifications will be handled.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
