### PR TITLE
RIA-5218 End application document generation changes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -325,7 +325,11 @@ public enum BailCaseFieldDefinition {
     TRIBUNAL_DOCUMENTS_WITH_METADATA(
         "tribunalDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     END_APPLICATION_DATE(
-        "endApplicationDate", new TypeReference<String>(){})
+        "endApplicationDate", new TypeReference<String>(){}),
+    END_APPLICATION_OUTCOME(
+        "endApplicationOutcome", new TypeReference<String>(){}),
+    END_APPLICATION_REASONS(
+        "endApplicationReasons", new TypeReference<String>(){}),
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -48,7 +48,8 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<BailCas
     private List<Event> getEventsToHandle() {
         List<Event> eventsToHandle = Lists.newArrayList(
             Event.SUBMIT_APPLICATION,
-            Event.RECORD_THE_DECISION
+            Event.RECORD_THE_DECISION,
+            Event.END_APPLICATION
         );
         return eventsToHandle;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -57,7 +57,8 @@ public class GenerateDocumentHandlerTest {
                 boolean canHandle = generateDocumentHandler.canHandle(stage, callback);
                 if (stage.equals(PreSubmitCallbackStage.ABOUT_TO_SUBMIT) && Arrays.asList(
                     Event.SUBMIT_APPLICATION,
-                    Event.RECORD_THE_DECISION
+                    Event.RECORD_THE_DECISION,
+                    Event.END_APPLICATION
                 ).contains(event)) {
                     assertTrue(canHandle);
                 } else {
@@ -135,6 +136,22 @@ public class GenerateDocumentHandlerTest {
     public void should_handle_generate_document_signed_decision_notice_upload() {
         BailCase expectedBailCase = mock(BailCase.class);
         when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
+        when(documentGenerator.generate(callback)).thenReturn(expectedBailCase);
+
+        PreSubmitCallbackResponse response = generateDocumentHandler.handle(
+            PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
+            callback
+        );
+
+        assertNotNull(response);
+        assertEquals(expectedBailCase, response.getData());
+        verify(documentGenerator, times(1)).generate(callback);
+    }
+
+    @Test
+    public void should_handle_generate_document_end_application() {
+        BailCase expectedBailCase = mock(BailCase.class);
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION);
         when(documentGenerator.generate(callback)).thenReturn(expectedBailCase);
 
         PreSubmitCallbackResponse response = generateDocumentHandler.handle(


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-5218

### Change description ###

- Updated BailCaseFieldDefinitions with fields used in document
- Added new Document tag
- Changes to generate document handler for this new document, plus unit test.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
