### PR TITLE
Ria 5545 handle documents upload

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,5 +17,6 @@
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2022-22968</cve>
     <cve>CVE-2022-25647</cve>
+    <cve>CVE-2022-29885</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -255,8 +255,8 @@ public enum BailCaseFieldDefinition {
         "detentionFacility", new TypeReference<String>(){}),
     UPLOAD_BAIL_SUMMARY_DOCS(
         "uploadBailSummaryDocs", new TypeReference<List<IdValue<DocumentWithDescription>>>(){}),
-    UPLOAD_BAIL_SUMMARY_METADATA(
-        "uploadBailSummaryMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    HOME_OFFICE_DOCUMENTS_WITH_METADATA(
+        "homeOfficeDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     CONDITION_FOR_BAIL(
         "conditionsForBail", new TypeReference<List<String>>(){}),
     CONDITION_APPEARANCE(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -329,7 +329,10 @@ public enum BailCaseFieldDefinition {
         "endApplicationOutcome", new TypeReference<String>(){}),
     END_APPLICATION_REASONS(
         "endApplicationReasons", new TypeReference<String>(){}),
-    ;
+    UPLOAD_DOCUMENTS(
+        "uploadDocuments", new TypeReference<List<IdValue<DocumentWithDescription>>>(){}),
+    UPLOAD_DOCUMENTS_SUPPLIED_BY(
+        "uploadDocumentsSuppliedBy", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -332,7 +332,9 @@ public enum BailCaseFieldDefinition {
     UPLOAD_DOCUMENTS(
         "uploadDocuments", new TypeReference<List<IdValue<DocumentWithDescription>>>(){}),
     UPLOAD_DOCUMENTS_SUPPLIED_BY(
-        "uploadDocumentsSuppliedBy", new TypeReference<String>(){});
+        "uploadDocumentsSuppliedBy", new TypeReference<String>(){}),
+    UPLOAD_DOCUMENTS_CURRENT_USER(
+        "uploadDocumentsCurrentUser", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -333,8 +333,8 @@ public enum BailCaseFieldDefinition {
         "uploadDocuments", new TypeReference<List<IdValue<DocumentWithDescription>>>(){}),
     UPLOAD_DOCUMENTS_SUPPLIED_BY(
         "uploadDocumentsSuppliedBy", new TypeReference<String>(){}),
-    UPLOAD_DOCUMENTS_CURRENT_USER(
-        "uploadDocumentsCurrentUser", new TypeReference<String>(){});
+    CURRENT_USER(
+        "currentUser", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
@@ -10,6 +10,7 @@ public enum DocumentTag {
     BAIL_SUMMARY("uploadBailSummary"),
     SIGNED_DECISION_NOTICE("signedDecisionNotice"),
     BAIL_DECISION_UNSIGNED("bailDecisionUnsigned"),
+    UPLOAD_DOCUMENT("uploadDocument"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -13,6 +13,7 @@ public enum Event {
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
     MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),
+    UPLOAD_DOCUMENTS("uploadDocuments"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmation.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class DocumentsUploadedConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(Callback<BailCase> callback) {
+        return (callback.getEvent() == Event.UPLOAD_DOCUMENTS);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+        postSubmitResponse.setConfirmationHeader("# Your upload is complete");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\n\n"
+            + "The document(s) you uploaded are available to view in the [documents tab](/cases/case-details/"
+            + callback.getCaseDetails().getId()
+            + "#Documents)."
+        );
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppender.java
@@ -35,7 +35,8 @@ public class ApplicationUserRoleAppender implements PreSubmitCallbackHandler<Bai
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
-            && (callback.getEvent() == Event.START_APPLICATION);
+            && (callback.getEvent() == Event.START_APPLICATION
+               || callback.getEvent() == Event.UPLOAD_DOCUMENTS);
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppender.java
@@ -48,19 +48,19 @@ public class CurrentUserRoleAppender implements PreSubmitCallbackHandler<BailCas
 
         UserRoleLabel userRoleLabel = userDetailsHelper.getLoggedInUserRoleLabel(userDetails);
         if (userRoleLabel.equals(UserRoleLabel.ADMIN_OFFICER)) {
-            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+            bailCase.write(BailCaseFieldDefinition.CURRENT_USER,
                            UserRoleLabel.ADMIN_OFFICER.toString());
         }
         if (userRoleLabel.equals(UserRoleLabel.LEGAL_REPRESENTATIVE)) {
-            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+            bailCase.write(BailCaseFieldDefinition.CURRENT_USER,
                            UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
         }
         if (userRoleLabel.equals(UserRoleLabel.HOME_OFFICE_GENERIC)) {
-            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+            bailCase.write(BailCaseFieldDefinition.CURRENT_USER,
                            UserRoleLabel.HOME_OFFICE_GENERIC.toString());
         }
         if (userRoleLabel.equals(UserRoleLabel.JUDGE)) {
-            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+            bailCase.write(BailCaseFieldDefinition.CURRENT_USER,
                            UserRoleLabel.JUDGE.toString());
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppender.java
@@ -12,17 +12,15 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
-public class ApplicationUserRoleAppender implements PreSubmitCallbackHandler<BailCase> {
+public class CurrentUserRoleAppender implements PreSubmitCallbackHandler<BailCase> {
 
     private final UserDetails userDetails;
     private final UserDetailsHelper userDetailsHelper;
 
-
-    public ApplicationUserRoleAppender(UserDetails userDetails, UserDetailsHelper userDetailsHelper) {
+    public CurrentUserRoleAppender(UserDetails userDetails, UserDetailsHelper userDetailsHelper) {
         this.userDetails = userDetails;
         this.userDetailsHelper = userDetailsHelper;
     }
@@ -35,7 +33,7 @@ public class ApplicationUserRoleAppender implements PreSubmitCallbackHandler<Bai
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
-               && (callback.getEvent() == Event.START_APPLICATION);
+               && (callback.getEvent() == Event.UPLOAD_DOCUMENTS);
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(
@@ -50,19 +48,20 @@ public class ApplicationUserRoleAppender implements PreSubmitCallbackHandler<Bai
 
         UserRoleLabel userRoleLabel = userDetailsHelper.getLoggedInUserRoleLabel(userDetails);
         if (userRoleLabel.equals(UserRoleLabel.ADMIN_OFFICER)) {
-            bailCase.write(BailCaseFieldDefinition.IS_ADMIN, YesOrNo.YES);
-        } else {
-            bailCase.write(BailCaseFieldDefinition.IS_ADMIN, YesOrNo.NO);
+            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+                           UserRoleLabel.ADMIN_OFFICER.toString());
         }
         if (userRoleLabel.equals(UserRoleLabel.LEGAL_REPRESENTATIVE)) {
-            bailCase.write(BailCaseFieldDefinition.IS_LEGAL_REP, YesOrNo.YES);
-        } else {
-            bailCase.write(BailCaseFieldDefinition.IS_LEGAL_REP, YesOrNo.NO);
+            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+                           UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
         }
         if (userRoleLabel.equals(UserRoleLabel.HOME_OFFICE_GENERIC)) {
-            bailCase.write(BailCaseFieldDefinition.IS_HOME_OFFICE, YesOrNo.YES);
-        } else {
-            bailCase.write(BailCaseFieldDefinition.IS_HOME_OFFICE, YesOrNo.NO);
+            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+                           UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+        }
+        if (userRoleLabel.equals(UserRoleLabel.JUDGE)) {
+            bailCase.write(BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER,
+                           UserRoleLabel.JUDGE.toString());
         }
 
         return new PreSubmitCallbackResponse<>(bailCase);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadBailSummaryDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadBailSummaryDocumentHandler.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_DOCS;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_METADATA;
 
 import java.util.Collections;
 import java.util.List;
@@ -73,16 +73,16 @@ public class UploadBailSummaryDocumentHandler implements PreSubmitCallbackHandle
                     .map(Optional::get)
                     .collect(Collectors.toList());
 
-            Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingBailSummaryDocuments =
-                bailCase.read(UPLOAD_BAIL_SUMMARY_METADATA);
+            Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingHomeOfficeDocuments =
+                bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA);
 
-            final List<IdValue<DocumentWithMetadata>> existingExistingBailSummaryDocuments =
-                maybeExistingBailSummaryDocuments.orElse(Collections.emptyList());
+            final List<IdValue<DocumentWithMetadata>> existingHomeOfficeDocuments =
+                maybeExistingHomeOfficeDocuments.orElse(Collections.emptyList());
 
             List<IdValue<DocumentWithMetadata>> allBailSummaryDocuments =
-                documentsAppender.append(existingExistingBailSummaryDocuments, bailSummary);
+                documentsAppender.append(existingHomeOfficeDocuments, bailSummary);
 
-            bailCase.write(UPLOAD_BAIL_SUMMARY_METADATA, allBailSummaryDocuments);
+            bailCase.write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allBailSummaryDocuments);
         }
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_USER;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
 
 import java.util.Collections;
@@ -63,7 +63,7 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
         }
 
         final BailCase bailCase = callback.getCaseDetails().getCaseData();
-        String userRole = bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class).orElse("");
+        String userRole = bailCase.read(CURRENT_USER, String.class).orElse("");
 
         Optional<List<IdValue<DocumentWithDescription>>> maybeDocument = bailCase.read(UPLOAD_DOCUMENTS);
         Optional<String> maybeSuppliedBy = bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY);
@@ -102,7 +102,7 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
 
             bailCase.clear(UPLOAD_DOCUMENTS);
             bailCase.clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
-            bailCase.clear(UPLOAD_DOCUMENTS_CURRENT_USER);
+            bailCase.clear(CURRENT_USER);
         }
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
@@ -88,14 +88,14 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
             BailCaseFieldDefinition appropriateCollectionForUserRole =
                 selectAppropriateDocumentsCollection(bailCase, suppliedBy);
 
-            Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingDocuments =
+            Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingDocumentsCollection =
                 bailCase.read(appropriateCollectionForUserRole);
 
-            final List<IdValue<DocumentWithMetadata>> existingHomeOfficeDocuments =
-                maybeExistingDocuments.orElse(Collections.emptyList());
+            final List<IdValue<DocumentWithMetadata>> existingDocuments =
+                maybeExistingDocumentsCollection.orElse(Collections.emptyList());
 
             List<IdValue<DocumentWithMetadata>> allDocuments =
-                documentsAppender.append(existingHomeOfficeDocuments, document);
+                documentsAppender.append(existingDocuments, document);
 
             bailCase.write(appropriateCollectionForUserRole, allDocuments);
 
@@ -132,7 +132,7 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
         }
 
         if (appropriateDocumentsCollection == null) {
-            throw new IllegalStateException("Impossible to determine which collection to append the document to");
+            throw new IllegalStateException("Unable to determine the supplier of the document");
         }
 
         return appropriateDocumentsCollection;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
@@ -31,9 +31,9 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
 
     private final DocumentReceiver documentReceiver;
     private final DocumentsAppender documentsAppender;
-    private final static String SUPPLIED_BY_APPLICANT = "Applicant";
-    private final static String SUPPLIED_BY_LEGAL_REPRESENTATIVE = "Legal Representative";
-    private final static String SUPPLIED_BY_HOME_OFFICE = "Home Office";
+    private static final String SUPPLIED_BY_APPLICANT = "Applicant";
+    private static final String SUPPLIED_BY_LEGAL_REPRESENTATIVE = "Legal Representative";
+    private static final String SUPPLIED_BY_HOME_OFFICE = "Home Office";
 
     public UploadDocumentsHandler(
         DocumentReceiver documentReceiver,
@@ -123,7 +123,8 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
         } else if (isLegalRep(bailCase)) {
             appropriateDocumentsCollection = APPLICANT_DOCUMENTS_WITH_METADATA;
         } else {
-            appropriateDocumentsCollection = suppliedBy.equals(SUPPLIED_BY_APPLICANT) || suppliedBy.equals(SUPPLIED_BY_LEGAL_REPRESENTATIVE)
+            appropriateDocumentsCollection = suppliedBy.equals(SUPPLIED_BY_APPLICANT)
+                                             || suppliedBy.equals(SUPPLIED_BY_LEGAL_REPRESENTATIVE)
                 ? APPLICANT_DOCUMENTS_WITH_METADATA
                 : suppliedBy.equals(SUPPLIED_BY_HOME_OFFICE)
                 ? HOME_OFFICE_DOCUMENTS_WITH_METADATA

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
 
 import java.util.Collections;
@@ -16,12 +17,12 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithDescription;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentReceiver;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentsAppender;
@@ -31,17 +32,16 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
 
     private final DocumentReceiver documentReceiver;
     private final DocumentsAppender documentsAppender;
-    private static final String SUPPLIED_BY_APPLICANT = "Applicant";
-    private static final String SUPPLIED_BY_LEGAL_REPRESENTATIVE = "Legal Representative";
-    private static final String SUPPLIED_BY_HOME_OFFICE = "Home Office";
 
-    public UploadDocumentsHandler(
-        DocumentReceiver documentReceiver,
-        DocumentsAppender documentsAppender
-    ) {
+    public UploadDocumentsHandler(DocumentReceiver documentReceiver,
+                                  DocumentsAppender documentsAppender) {
         this.documentReceiver = documentReceiver;
         this.documentsAppender = documentsAppender;
     }
+
+    private static final String SUPPLIED_BY_APPLICANT = "applicant";
+    private static final String SUPPLIED_BY_LEGAL_REPRESENTATIVE = "legalRepresentative";
+    private static final String SUPPLIED_BY_HOME_OFFICE = "homeOffice";
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -63,14 +63,15 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
         }
 
         final BailCase bailCase = callback.getCaseDetails().getCaseData();
+        String userRole = bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class).orElse("");
 
         Optional<List<IdValue<DocumentWithDescription>>> maybeDocument = bailCase.read(UPLOAD_DOCUMENTS);
         Optional<String> maybeSuppliedBy = bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY);
 
         String suppliedBy = maybeSuppliedBy
-            .orElse(isLegalRep(bailCase)
+            .orElse(currentUserIsLegalRep(userRole)
                         ? "Legal Representative"
-                        : isHomeOffice(bailCase)
+                        : currentUserIsHomeOfficer(userRole)
                 ? "Home Office"
                 : "");
 
@@ -86,7 +87,7 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
                     .collect(Collectors.toList());
 
             BailCaseFieldDefinition appropriateCollectionForUserRole =
-                selectAppropriateDocumentsCollection(bailCase, suppliedBy);
+                selectAppropriateDocumentsCollection(userRole, suppliedBy);
 
             Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingDocumentsCollection =
                 bailCase.read(appropriateCollectionForUserRole);
@@ -101,28 +102,34 @@ public class UploadDocumentsHandler implements PreSubmitCallbackHandler<BailCase
 
             bailCase.clear(UPLOAD_DOCUMENTS);
             bailCase.clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
+            bailCase.clear(UPLOAD_DOCUMENTS_CURRENT_USER);
         }
         return new PreSubmitCallbackResponse<>(bailCase);
     }
 
-    private boolean isLegalRep(BailCase bailCase) {
-        return bailCase.read(BailCaseFieldDefinition.IS_LEGAL_REP, YesOrNo.class).map(flag -> flag.equals(
-            YesOrNo.YES)).orElse(false);
+    private boolean currentUserIsLegalRep(String userRole) {
+        return userRole.equals(UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
     }
 
-    private boolean isHomeOffice(BailCase bailCase) {
-        return bailCase.read(BailCaseFieldDefinition.IS_HOME_OFFICE, YesOrNo.class).map(flag -> flag.equals(
-            YesOrNo.YES)).orElse(false);
+    private boolean currentUserIsHomeOfficer(String userRole) {
+        return userRole.equals(UserRoleLabel.HOME_OFFICE_GENERIC.toString());
     }
 
-    private BailCaseFieldDefinition selectAppropriateDocumentsCollection(BailCase bailCase, String suppliedBy) {
-        BailCaseFieldDefinition appropriateDocumentsCollection;
+    private boolean currentUserIsAdminOrJudge(String userRole) {
+        return userRole.equals(UserRoleLabel.ADMIN_OFFICER.toString())
+            || userRole.equals(UserRoleLabel.JUDGE.toString());
+    }
 
-        if (isHomeOffice(bailCase)) {
+    private BailCaseFieldDefinition selectAppropriateDocumentsCollection(String userRole, String suppliedBy) {
+        BailCaseFieldDefinition appropriateDocumentsCollection = null;
+
+        if (currentUserIsHomeOfficer(userRole)) {
             appropriateDocumentsCollection = HOME_OFFICE_DOCUMENTS_WITH_METADATA;
-        } else if (isLegalRep(bailCase)) {
+        }
+        if (currentUserIsLegalRep(userRole)) {
             appropriateDocumentsCollection = APPLICANT_DOCUMENTS_WITH_METADATA;
-        } else {
+        }
+        if (currentUserIsAdminOrJudge(userRole)) {
             appropriateDocumentsCollection = suppliedBy.equals(SUPPLIED_BY_APPLICANT)
                                              || suppliedBy.equals(SUPPLIED_BY_LEGAL_REPRESENTATIVE)
                 ? APPLICANT_DOCUMENTS_WITH_METADATA

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandler.java
@@ -3,10 +3,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_ADMIN;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_HOME_OFFICE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.TRIBUNAL_DOCUMENTS_WITH_METADATA;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_DOCS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
@@ -14,13 +14,14 @@ public class DocumentTagTest {
         assertEquals("uploadBailSummary", DocumentTag.BAIL_SUMMARY.toString());
         assertEquals("signedDecisionNotice", DocumentTag.SIGNED_DECISION_NOTICE.toString());
         assertEquals("bailDecisionUnsigned", DocumentTag.BAIL_DECISION_UNSIGNED.toString());
+        assertEquals("uploadDocument", DocumentTag.UPLOAD_DOCUMENT.toString());
         assertEquals("", DocumentTag.NONE.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(6, DocumentTag.values().length);
+        assertEquals(7, DocumentTag.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -16,11 +16,12 @@ public class EventTest {
         assertEquals("uploadSignedDecisionNotice", Event.UPLOAD_SIGNED_DECISION_NOTICE.toString());
         assertEquals("addCaseNote", Event.ADD_CASE_NOTE.toString());
         assertEquals("moveApplicationToDecided", Event.MOVE_APPLICATION_TO_DECIDED.toString());
+        assertEquals("uploadDocuments", Event.UPLOAD_DOCUMENTS.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(9, Event.values().length);
+        assertEquals(10, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmationTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DocumentsUploadedConfirmationTest {
+
+    @Mock private Callback<BailCase> callback;
+
+    @Mock private CaseDetails<BailCase> caseDetails;
+    private DocumentsUploadedConfirmation documentsUploadedConfirmation;
+
+    @BeforeEach
+    public void setUp() {
+        documentsUploadedConfirmation = new DocumentsUploadedConfirmation();
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+    }
+
+    @Test
+    void should_not_allow_null_args() {
+        assertThatThrownBy(() -> documentsUploadedConfirmation.handle(null))
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_handle_invalid_callback() {
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION); //Invalid event for this handler
+
+        assertThatThrownBy(() -> documentsUploadedConfirmation.handle(callback)).isExactlyInstanceOf(
+            IllegalStateException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/DocumentsUploadedConfirmationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +14,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class DocumentsUploadedConfirmationTest {
@@ -35,9 +38,26 @@ public class DocumentsUploadedConfirmationTest {
 
     @Test
     void should_not_handle_invalid_callback() {
-        when(callback.getEvent()).thenReturn(Event.END_APPLICATION); //Invalid event for this handler
+        when(callback.getEvent()).thenReturn(Event.MOVE_APPLICATION_TO_DECIDED); //Invalid event for this handler
 
         assertThatThrownBy(() -> documentsUploadedConfirmation.handle(callback)).isExactlyInstanceOf(
             IllegalStateException.class);
+    }
+
+    @Test
+    void should_set_header_body() {
+        long caseId = 1000L;
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getId()).thenReturn(caseId);
+        PostSubmitCallbackResponse response = documentsUploadedConfirmation.handle(callback);
+
+        assertNotNull(response.getConfirmationBody(), "Confirmation Body is null");
+        assertThat(response.getConfirmationBody().get()).contains("#### What happens next\n\n"
+                                                                  + "The document(s) you uploaded are available to view"
+                                                                  + " in the [documents tab](/cases/case-details/"
+                                                                  + "1000#Documents).");
+
+        assertNotNull(response.getConfirmationHeader(), "Confirmation Header is null");
+        assertThat(response.getConfirmationHeader().get()).isEqualTo("# Your upload is complete");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppenderTest.java
@@ -191,7 +191,8 @@ class ApplicationUserRoleAppenderTest {
             for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
                 boolean canHandle = applicationUserRoleAppender.canHandle(callbackStage, callback);
                 if (callbackStage == ABOUT_TO_START
-                    && (callback.getEvent() == Event.START_APPLICATION)) {
+                    && (callback.getEvent() == Event.START_APPLICATION
+                    || callback.getEvent() == Event.UPLOAD_DOCUMENTS)) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationUserRoleAppenderTest.java
@@ -191,8 +191,7 @@ class ApplicationUserRoleAppenderTest {
             for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
                 boolean canHandle = applicationUserRoleAppender.canHandle(callbackStage, callback);
                 if (callbackStage == ABOUT_TO_START
-                    && (callback.getEvent() == Event.START_APPLICATION
-                    || callback.getEvent() == Event.UPLOAD_DOCUMENTS)) {
+                    && (callback.getEvent() == Event.START_APPLICATION)) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppenderTest.java
@@ -63,13 +63,13 @@ public class CurrentUserRoleAppenderTest {
         assertThat(response.getData()).isEqualTo(bailCase);
         assertThat(response.getErrors()).isEmpty();
         verify(bailCase, times(1)).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.JUDGE.toString());
     }
 
     @Test
@@ -88,13 +88,13 @@ public class CurrentUserRoleAppenderTest {
         assertThat(response.getData()).isEqualTo(bailCase);
         assertThat(response.getErrors()).isEmpty();
         verify(bailCase, times(1)).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.JUDGE.toString());
     }
 
     @Test
@@ -114,13 +114,13 @@ public class CurrentUserRoleAppenderTest {
         assertThat(response.getData()).isEqualTo(bailCase);
         assertThat(response.getErrors()).isEmpty();
         verify(bailCase, times(1)).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.JUDGE.toString());
     }
 
     @Test
@@ -140,13 +140,13 @@ public class CurrentUserRoleAppenderTest {
         assertThat(response.getData()).isEqualTo(bailCase);
         assertThat(response.getErrors()).isEmpty();
         verify(bailCase, times(1)).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.JUDGE.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
         verify(bailCase, never()).write(
-            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+            BailCaseFieldDefinition.CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
     }
 
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentUserRoleAppenderTest.java
@@ -1,0 +1,187 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@ExtendWith(MockitoExtension.class)
+public class CurrentUserRoleAppenderTest {
+
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    @Mock
+    private UserDetails userDetails;
+    @Mock
+    private UserDetailsHelper userDetailsHelper;
+
+    private CurrentUserRoleAppender currentUserRoleAppender;
+
+    @BeforeEach
+    public void setUp() {
+        currentUserRoleAppender =
+            new CurrentUserRoleAppender(userDetails, userDetailsHelper);
+    }
+
+    @Test
+    void handler_writes_admin_as_current_user() {
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+
+
+        PreSubmitCallbackResponse<BailCase> response =
+            currentUserRoleAppender.handle(ABOUT_TO_START, callback);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData()).isEqualTo(bailCase);
+        assertThat(response.getErrors()).isEmpty();
+        verify(bailCase, times(1)).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+    }
+
+    @Test
+    void handler_writes_home_office_as_current_user() {
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.HOME_OFFICE_GENERIC);
+
+
+        PreSubmitCallbackResponse<BailCase> response =
+            currentUserRoleAppender.handle(ABOUT_TO_START, callback);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData()).isEqualTo(bailCase);
+        assertThat(response.getErrors()).isEmpty();
+        verify(bailCase, times(1)).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+    }
+
+    @Test
+    void handler_writes_legal_rep_as_current_user() {
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
+
+
+        PreSubmitCallbackResponse<BailCase> response =
+            currentUserRoleAppender.handle(ABOUT_TO_START, callback);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData()).isEqualTo(bailCase);
+        assertThat(response.getErrors()).isEmpty();
+        verify(bailCase, times(1)).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+    }
+
+    @Test
+    void handler_writes_judge_as_current_user() {
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.JUDGE);
+
+
+        PreSubmitCallbackResponse<BailCase> response =
+            currentUserRoleAppender.handle(ABOUT_TO_START, callback);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData()).isEqualTo(bailCase);
+        assertThat(response.getErrors()).isEmpty();
+        verify(bailCase, times(1)).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.JUDGE.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.ADMIN_OFFICER.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.HOME_OFFICE_GENERIC.toString());
+        verify(bailCase, never()).write(
+            BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER, UserRoleLabel.LEGAL_REPRESENTATIVE.toString());
+    }
+
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> currentUserRoleAppender.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> currentUserRoleAppender.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> currentUserRoleAppender.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> currentUserRoleAppender.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+    @Test
+    void handler_throws_error_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> currentUserRoleAppender.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        assertThatThrownBy(() -> currentUserRoleAppender.handle(ABOUT_TO_START, callback))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadBailSummaryDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadBailSummaryDocumentHandlerTest.java
@@ -10,8 +10,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_DOCS;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_METADATA;
 
 import java.util.Arrays;
 import java.util.List;
@@ -98,7 +98,7 @@ public class UploadBailSummaryDocumentHandlerTest {
                 bailSummary2WithMetadata
             );
 
-        when(bailCase.read(UPLOAD_BAIL_SUMMARY_METADATA)).thenReturn(Optional.of(existingBailSummaryDocuments));
+        when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingBailSummaryDocuments));
         when(bailCase.read(UPLOAD_BAIL_SUMMARY_DOCS)).thenReturn(Optional.of(summaryWithDescriptionList));
 
         when(documentReceiver.tryReceive(bailSummary1, DocumentTag.BAIL_SUMMARY))
@@ -123,7 +123,7 @@ public class UploadBailSummaryDocumentHandlerTest {
 
         verify(documentsAppender, times(1)).append(existingBailSummaryDocuments, summaryList);
 
-        verify(bailCase, times(1)).write(UPLOAD_BAIL_SUMMARY_METADATA, allBailSummaryDocuments);
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allBailSummaryDocuments);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class UploadBailSummaryDocumentHandlerTest {
             singletonList(new IdValue<>("1", bailSummary1));
         List<DocumentWithMetadata> summaryList = singletonList(bailSummary1WithMetadata);
 
-        when(bailCase.read(UPLOAD_BAIL_SUMMARY_METADATA)).thenReturn(Optional.empty());
+        when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.empty());
         when(bailCase.read(UPLOAD_BAIL_SUMMARY_DOCS)).thenReturn(Optional.of(summaryWithDescriptionList));
 
         when(documentReceiver.tryReceive(bailSummary1, DocumentTag.BAIL_SUMMARY))
@@ -162,7 +162,7 @@ public class UploadBailSummaryDocumentHandlerTest {
 
         assertEquals(0, actualExistingSummaryDocuments.size());
 
-        verify(bailCase, times(1)).write(UPLOAD_BAIL_SUMMARY_METADATA, allBailSummaryDocuments);
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allBailSummaryDocuments);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
@@ -1,12 +1,9 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,7 +11,6 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_HOME_OFFICE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_LEGAL_REP;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_DOCS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
@@ -1,0 +1,344 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.APPLICANT_DOCUMENTS_WITH_METADATA;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_DOCUMENTS_WITH_METADATA;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_HOME_OFFICE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_LEGAL_REP;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_BAIL_SUMMARY_DOCS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithDescription;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentReceiver;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.DocumentsAppender;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class UploadDocumentsHandlerTest {
+    @Mock
+    private DocumentReceiver documentReceiver;
+    @Mock
+    private DocumentsAppender documentsAppender;
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    @Mock
+    private DocumentWithDescription homeOfficeDocumentBeingUploaded1;
+    @Mock
+    private DocumentWithDescription homeOfficeDocumentBeingUploaded2;
+    @Mock
+    private DocumentWithMetadata homeOfficeDocumentBeingUploaded1WithMetadata;
+    @Mock
+    private DocumentWithMetadata homeOfficeDocumentBeingUploaded2WithMetadata;
+    @Mock
+    private List<IdValue<DocumentWithMetadata>> existingHomeOfficeDocuments;
+    @Mock
+    private List<IdValue<DocumentWithMetadata>> allHomeOfficeDocuments;
+    @Mock
+    private DocumentWithDescription applicantDocumentBeingUploaded1;
+    @Mock
+    private DocumentWithDescription applicantDocumentBeingUploaded2;
+    @Mock
+    private DocumentWithMetadata applicantDocumentBeingUploaded1WithMetadata;
+    @Mock
+    private DocumentWithMetadata applicantDocumentBeingUploaded2WithMetadata;
+    @Mock
+    private List<IdValue<DocumentWithMetadata>> existingApplicantDocuments;
+    @Mock
+    private List<IdValue<DocumentWithMetadata>> allApplicantDocuments;
+
+    @Captor
+    private ArgumentCaptor<List<IdValue<DocumentWithMetadata>>> existingHomeOfficeDocumentsCaptor;
+
+    private UploadDocumentsHandler uploadDocumentsDocumentHandler;
+
+    @BeforeEach
+    public void setUp() {
+        uploadDocumentsDocumentHandler =
+            new UploadDocumentsHandler(
+                documentReceiver,
+                documentsAppender
+            );
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_DOCUMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+    }
+
+    @Test
+    void should_allow_home_office_user_to_append_home_office_docs_to_existing_ones() {
+
+        List<IdValue<DocumentWithDescription>> homeOfficeDocumentsWithDescriptionList =
+            Arrays.asList(
+                new IdValue<>("1", homeOfficeDocumentBeingUploaded1),
+                new IdValue<>("2", homeOfficeDocumentBeingUploaded2)
+            );
+
+        List<DocumentWithMetadata> homeOfficeDocumentsWithMetadataList =
+            Arrays.asList(
+                homeOfficeDocumentBeingUploaded1WithMetadata,
+                homeOfficeDocumentBeingUploaded2WithMetadata
+            );
+
+        when(bailCase.read(IS_HOME_OFFICE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingHomeOfficeDocuments));
+        when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(homeOfficeDocumentsWithDescriptionList));
+
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Home Office"))
+            .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded1WithMetadata));
+
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Home Office"))
+            .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded2WithMetadata));
+
+        when(documentsAppender.append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList))
+            .thenReturn(allHomeOfficeDocuments);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(bailCase, callbackResponse.getData());
+
+        verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
+
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Home Office");
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Home Office");
+
+        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList);
+
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allHomeOfficeDocuments);
+
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
+    }
+
+    @Test
+    void should_allow_legal_rep_user_to_append_applicant_docs_to_existing_ones() {
+
+        List<IdValue<DocumentWithDescription>> applicantDocumentsWithDescriptionList =
+            Arrays.asList(
+                new IdValue<>("1", applicantDocumentBeingUploaded1),
+                new IdValue<>("2", applicantDocumentBeingUploaded2)
+            );
+
+        List<DocumentWithMetadata> applicantDocumentsWithMetadataList =
+            Arrays.asList(
+                applicantDocumentBeingUploaded1WithMetadata,
+                applicantDocumentBeingUploaded2WithMetadata
+            );
+
+        when(bailCase.read(IS_LEGAL_REP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(bailCase.read(APPLICANT_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingApplicantDocuments));
+        when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(applicantDocumentsWithDescriptionList));
+
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative"))
+            .thenReturn(Optional.of(applicantDocumentBeingUploaded1WithMetadata));
+
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative"))
+            .thenReturn(Optional.of(applicantDocumentBeingUploaded2WithMetadata));
+
+        when(documentsAppender.append(existingApplicantDocuments, applicantDocumentsWithMetadataList))
+            .thenReturn(allApplicantDocuments);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(bailCase, callbackResponse.getData());
+
+        verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
+
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
+
+        verify(documentsAppender, times(1)).append(existingApplicantDocuments, applicantDocumentsWithMetadataList);
+
+        verify(bailCase, times(1)).write(APPLICANT_DOCUMENTS_WITH_METADATA, allApplicantDocuments);
+
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Legal Representative", "Applicant"})
+    void should_allow_admin_or_judge_to_append_applicant_docs_to_existing_ones(String suppliedBy) {
+
+        when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(suppliedBy));
+
+        List<IdValue<DocumentWithDescription>> applicantDocumentsWithDescriptionList =
+            Arrays.asList(
+                new IdValue<>("1", applicantDocumentBeingUploaded1),
+                new IdValue<>("2", applicantDocumentBeingUploaded2)
+            );
+
+        List<DocumentWithMetadata> applicantDocumentsWithMetadataList =
+            Arrays.asList(
+                applicantDocumentBeingUploaded1WithMetadata,
+                applicantDocumentBeingUploaded2WithMetadata
+            );
+
+        when(bailCase.read(APPLICANT_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingApplicantDocuments));
+        when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(applicantDocumentsWithDescriptionList));
+
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedBy))
+            .thenReturn(Optional.of(applicantDocumentBeingUploaded1WithMetadata));
+
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedBy))
+            .thenReturn(Optional.of(applicantDocumentBeingUploaded2WithMetadata));
+
+        when(documentsAppender.append(existingApplicantDocuments, applicantDocumentsWithMetadataList))
+            .thenReturn(allApplicantDocuments);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(bailCase, callbackResponse.getData());
+
+        verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
+
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
+
+        verify(documentsAppender, times(1)).append(existingApplicantDocuments, applicantDocumentsWithMetadataList);
+
+        verify(bailCase, times(1)).write(APPLICANT_DOCUMENTS_WITH_METADATA, allApplicantDocuments);
+
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
+    }
+
+    @Test
+    void should_allow_admin_or_judge_to_append_home_office_docs_to_existing_ones() {
+
+        String suppliedByHomeOffice = "Home Office";
+        when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(suppliedByHomeOffice));
+
+        List<IdValue<DocumentWithDescription>> homeOfficeDocumentsWithDescriptionList =
+            Arrays.asList(
+                new IdValue<>("1", homeOfficeDocumentBeingUploaded1),
+                new IdValue<>("2", homeOfficeDocumentBeingUploaded2)
+            );
+
+        List<DocumentWithMetadata> homeOfficeDocumentsWithMetadataList =
+            Arrays.asList(
+                homeOfficeDocumentBeingUploaded1WithMetadata,
+                homeOfficeDocumentBeingUploaded2WithMetadata
+            );
+
+        when(bailCase.read(IS_HOME_OFFICE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingHomeOfficeDocuments));
+        when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(homeOfficeDocumentsWithDescriptionList));
+
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice))
+            .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded1WithMetadata));
+
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice))
+            .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded2WithMetadata));
+
+        when(documentsAppender.append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList))
+            .thenReturn(allHomeOfficeDocuments);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(bailCase, callbackResponse.getData());
+
+        verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
+
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
+
+        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList);
+
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allHomeOfficeDocuments);
+
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
+        verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
+    }
+
+    @Test
+    void should_not_change_uploaded_documents_if_not_present() {
+
+        when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.empty());
+        when(callback.getCaseDetails().getCaseData()).thenReturn(bailCase);
+
+        assertDoesNotThrow(() -> uploadDocumentsDocumentHandler
+            .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback));
+        PreSubmitCallbackResponse<BailCase> response = uploadDocumentsDocumentHandler
+            .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertEquals(bailCase, response.getData());
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(
+            () -> uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> uploadDocumentsDocumentHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+            () -> uploadDocumentsDocumentHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadDocumentsDocumentHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadDocumentsDocumentHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
@@ -118,10 +118,12 @@ public class UploadDocumentsHandlerTest {
         when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingHomeOfficeDocuments));
         when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(homeOfficeDocumentsWithDescriptionList));
 
-        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Home Office"))
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT,
+                                         "Home Office"))
             .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded1WithMetadata));
 
-        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Home Office"))
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT,
+                                         "Home Office"))
             .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded2WithMetadata));
 
         when(documentsAppender.append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList))
@@ -135,12 +137,16 @@ public class UploadDocumentsHandlerTest {
 
         verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
 
-        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Home Office");
-        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Home Office");
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1,
+                                                      DocumentTag.UPLOAD_DOCUMENT, "Home Office");
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2,
+                                                      DocumentTag.UPLOAD_DOCUMENT, "Home Office");
 
-        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList);
+        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments,
+                                                   homeOfficeDocumentsWithMetadataList);
 
-        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allHomeOfficeDocuments);
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA,
+                                         allHomeOfficeDocuments);
 
         verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
         verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);
@@ -166,10 +172,12 @@ public class UploadDocumentsHandlerTest {
         when(bailCase.read(APPLICANT_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingApplicantDocuments));
         when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(applicantDocumentsWithDescriptionList));
 
-        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative"))
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT,
+                                         "Legal Representative"))
             .thenReturn(Optional.of(applicantDocumentBeingUploaded1WithMetadata));
 
-        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative"))
+        when(documentReceiver.tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT,
+                                         "Legal Representative"))
             .thenReturn(Optional.of(applicantDocumentBeingUploaded2WithMetadata));
 
         when(documentsAppender.append(existingApplicantDocuments, applicantDocumentsWithMetadataList))
@@ -183,10 +191,13 @@ public class UploadDocumentsHandlerTest {
 
         verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
 
-        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
-        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1,
+                                                      DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2,
+                                                      DocumentTag.UPLOAD_DOCUMENT, "Legal Representative");
 
-        verify(documentsAppender, times(1)).append(existingApplicantDocuments, applicantDocumentsWithMetadataList);
+        verify(documentsAppender, times(1)).append(existingApplicantDocuments,
+                                                   applicantDocumentsWithMetadataList);
 
         verify(bailCase, times(1)).write(APPLICANT_DOCUMENTS_WITH_METADATA, allApplicantDocuments);
 
@@ -232,10 +243,13 @@ public class UploadDocumentsHandlerTest {
 
         verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
 
-        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
-        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded1,
+                                                      DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
+        verify(documentReceiver, times(1)).tryReceive(applicantDocumentBeingUploaded2,
+                                                      DocumentTag.UPLOAD_DOCUMENT, suppliedBy);
 
-        verify(documentsAppender, times(1)).append(existingApplicantDocuments, applicantDocumentsWithMetadataList);
+        verify(documentsAppender, times(1)).append(existingApplicantDocuments,
+                                                   applicantDocumentsWithMetadataList);
 
         verify(bailCase, times(1)).write(APPLICANT_DOCUMENTS_WITH_METADATA, allApplicantDocuments);
 
@@ -266,10 +280,12 @@ public class UploadDocumentsHandlerTest {
         when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingHomeOfficeDocuments));
         when(bailCase.read(UPLOAD_DOCUMENTS)).thenReturn(Optional.of(homeOfficeDocumentsWithDescriptionList));
 
-        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice))
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT,
+                                         suppliedByHomeOffice))
             .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded1WithMetadata));
 
-        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice))
+        when(documentReceiver.tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT,
+                                         suppliedByHomeOffice))
             .thenReturn(Optional.of(homeOfficeDocumentBeingUploaded2WithMetadata));
 
         when(documentsAppender.append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList))
@@ -283,12 +299,16 @@ public class UploadDocumentsHandlerTest {
 
         verify(bailCase, times(1)).read(UPLOAD_DOCUMENTS);
 
-        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
-        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2, DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded1,
+                                                      DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
+        verify(documentReceiver, times(1)).tryReceive(homeOfficeDocumentBeingUploaded2,
+                                                      DocumentTag.UPLOAD_DOCUMENT, suppliedByHomeOffice);
 
-        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments, homeOfficeDocumentsWithMetadataList);
+        verify(documentsAppender, times(1)).append(existingHomeOfficeDocuments,
+                                                   homeOfficeDocumentsWithMetadataList);
 
-        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA, allHomeOfficeDocuments);
+        verify(bailCase, times(1)).write(HOME_OFFICE_DOCUMENTS_WITH_METADATA,
+                                         allHomeOfficeDocuments);
 
         verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS);
         verify(bailCase, times(1)).clear(UPLOAD_DOCUMENTS_SUPPLIED_BY);

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadDocumentsHandlerTest.java
@@ -13,7 +13,7 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_ADMIN;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_HOME_OFFICE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_CURRENT_USER;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_USER;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_DOCUMENTS_SUPPLIED_BY;
 
 import java.util.Arrays;
@@ -116,7 +116,7 @@ public class UploadDocumentsHandlerTest {
                 homeOfficeDocumentBeingUploaded2WithMetadata
             );
 
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.of(UserRoleLabel.HOME_OFFICE_GENERIC.toString()));
 
         when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingHomeOfficeDocuments));
@@ -171,7 +171,7 @@ public class UploadDocumentsHandlerTest {
                 applicantDocumentBeingUploaded2WithMetadata
             );
 
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.of(UserRoleLabel.LEGAL_REPRESENTATIVE.toString()));
 
         when(bailCase.read(APPLICANT_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(existingApplicantDocuments));
@@ -214,7 +214,7 @@ public class UploadDocumentsHandlerTest {
     @ValueSource(strings = {"legalRepresentative", "applicant"})
     void should_allow_admin_or_judge_to_append_applicant_docs_to_existing_ones(String suppliedBy) {
 
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.of(UserRoleLabel.ADMIN_OFFICER.toString()));
         when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(suppliedBy));
 
@@ -267,7 +267,7 @@ public class UploadDocumentsHandlerTest {
     @Test
     void should_allow_admin_or_judge_to_append_home_office_docs_to_existing_ones() {
 
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.of(UserRoleLabel.ADMIN_OFFICER.toString()));
         String suppliedByHomeOffice = "homeOffice";
         when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(suppliedByHomeOffice));
@@ -372,7 +372,7 @@ public class UploadDocumentsHandlerTest {
 
         String wrongSupplier = "wrong value"; //valid values are: legalRepresentative, homeOffice, Applicant
         when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(wrongSupplier));
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.of(UserRoleLabel.ADMIN_OFFICER.toString()));
 
         List<IdValue<DocumentWithDescription>> homeOfficeDocumentsWithDescriptionList =
@@ -415,7 +415,7 @@ public class UploadDocumentsHandlerTest {
 
         String suppliedBy = "applicant"; //valid value
         when(bailCase.read(UPLOAD_DOCUMENTS_SUPPLIED_BY)).thenReturn(Optional.of(suppliedBy));
-        when(bailCase.read(UPLOAD_DOCUMENTS_CURRENT_USER, String.class))
+        when(bailCase.read(CURRENT_USER, String.class))
             .thenReturn(Optional.empty()); //should always be populated
 
         List<IdValue<DocumentWithDescription>> homeOfficeDocumentsWithDescriptionList =


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5545](https://tools.hmcts.net/jira/browse/RIA-5545)


### Change description ###
- Refactored 'UploadBailSummaryDocumentHandler' so that it appends the Bail Summary to a collection of documents called _Home Office documents_ (similar to the upload of a signedDecisionNotice being handled as an appendage of Tribunal documents)
- The refactor is necessary because of how the uploaded documents will look like in the documents tab. There will be (1) Applicant Documents, (2) Home Office Documents, (3) Tribunal Documents. And Bail Summary is a Home office document.

- Acceptance criteria require the following:
    - HO can upload a document (it's a **HO document**)
    - Legal Rep can upload a document (it's an **Applicant document**)
    - Admin/Judge can upload a document but have to select if it's a **HO document**, an **Applicant document**, or a Legal Rep document (**Applicant document**)

- based on the above, the event is first handled in CurrentUserRoleAppender(/aboutToStart) to update the "uploadDocumentsCurrentUser" flag whenever they pick up the case from the case list
- then handled by the UploadDocumentsHandler (/aboutToSubmit) and checks for:
    - the value of `suppliedBy` if there is one (`MANDATORY` for Admin/Judge) and adds the document to either HO documents or Applicant documents based on that
    - if there isn't a value (i.e. user must be HO or Legal Rep), then checks for `isLegalRep` and `isHomeOffice` and sets `suppliedBy` to HO or Legal Rep so the documents can be added to HO documents or Applicant documents based on that
- the "uploadDocumentsCurrentUser" flag is cleared before the end of the event so it isn't left with stale data

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
