### PR TITLE
Merge dev to master (#117)

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,5 +17,8 @@
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2022-22968</cve>
     <cve>CVE-2022-25647</cve>
+    <cve>CVE-2022-22970</cve>
+    <cve>CVE-2022-22971</cve>
+    <cve>CVE-2022-29885</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.NationalityFieldValue;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
@@ -19,13 +18,15 @@ public enum BailCaseFieldDefinition {
     IS_HOME_OFFICE(
         "isHomeOffice", new TypeReference<YesOrNo>() {}),
     CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE(
-        "currentCaseStateVisibleToLegalRepresentative", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToLegalRepresentative", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_JUDGE(
-        "currentCaseStateVisibleToJudge", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToJudge", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER(
-        "currentCaseStateVisibleToAdminOfficer", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToAdminOfficer", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE(
-        "currentCaseStateVisibleToHomeOffice", new TypeReference<State>(){}),
+        "currentCaseStateVisibleToHomeOffice", new TypeReference<String>(){}),
+    CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS(
+        "currentCaseStateVisibleToAllUsers", new TypeReference<String>(){}),
     APPLICANT_GIVEN_NAMES(
         "applicantGivenNames", new TypeReference<String>() {}),
     APPLICANT_FAMILY_NAME(
@@ -274,8 +275,6 @@ public enum BailCaseFieldDefinition {
         "secretaryOfStateRefusalReasons", new TypeReference<String>(){}),
     UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT(
         "uploadSignedDecisionNoticeDocument", new TypeReference<Document>(){}),
-    SIGNED_DECISION_NOTICE_METADATA(
-        "signedDecisionNoticeMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     DECISION_GRANTED_OR_REFUSED(
         "decisionGrantedOrRefused", new TypeReference<String>(){}),
     RECORD_THE_DECISION_LIST(
@@ -323,7 +322,9 @@ public enum BailCaseFieldDefinition {
     DECISION_UNSIGNED_DOCUMENT(
         "decisionUnsignedDocument", new TypeReference<Document>(){}),
     TRIBUNAL_DOCUMENTS_WITH_METADATA(
-        "tribunalDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){})
+        "tribunalDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    END_APPLICATION_DATE(
+        "endApplicationDate", new TypeReference<String>(){})
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
@@ -9,6 +9,7 @@ public enum DocumentTag {
     APPLICATION_SUBMISSION("applicationSubmission"),
     BAIL_SUMMARY("uploadBailSummary"),
     SIGNED_DECISION_NOTICE("signedDecisionNotice"),
+    BAIL_DECISION_UNSIGNED("bailDecisionUnsigned"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -12,6 +12,8 @@ public enum Event {
     RECORD_THE_DECISION("recordTheDecision"),
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
+    MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),
+
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateState.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateState.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * These enums are the intermediate states which are not being displayed as separate states.
+ * For ex: From Record_Decision event case can go from decided or ConditionalBail on UI but
+ * from UPLOAD_SIGNED_DECISION_NOTICE the state will not change. But we need to set the
+ * intermediate state in order to show/hide the fields in the tab.
+ */
+public enum IntermediateState {
+
+    SIGNED_DECISION_NOTICE_UPLOADED("signedDecisionNoticeUploaded"),
+    @JsonEnumDefaultValue
+    UNKNOWN("unknown");
+
+    @JsonValue
+    private final String id;
+
+    IntermediateState(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/State.java
@@ -10,7 +10,6 @@ public enum State {
     APPLICATION_ENDED("applicationEnded"),
     APPLICATION_SUBMITTED("applicationSubmitted"),
     BAIL_SUMMARY_UPLOADED("bailSummaryUploaded"),
-    SIGNED_DECISION_NOTICE_UPLOADED("signedDecisionNoticeUploaded"),
     DECISION_DECIDED("decisionDecided"),
     DECISION_CONDITIONAL_BAIL("decisionConditionalBail"),
     @JsonEnumDefaultValue

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmation.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class EndApplicationConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(
+        Callback<BailCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.END_APPLICATION;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+        postSubmitResponse.setConfirmationHeader("# You have ended the application");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\n\n"
+                + "A notification has been sent to all parties. "
+                + "No further action is required.<br>"
+        );
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MoveApplicationToDecidedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MoveApplicationToDecidedConfirmation.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class MoveApplicationToDecidedConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(Callback<BailCase> callback) {
+        return (callback.getEvent() == Event.MOVE_APPLICATION_TO_DECIDED);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
@@ -1,17 +1,23 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE;
+
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE;
+
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.RECORD_DECISION_TYPE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State.DECISION_CONDITIONAL_BAIL;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.DecisionType;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
+
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.IntermediateState;
+
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -38,7 +44,7 @@ public class CurrentCaseStateUpdater implements PreSubmitCallbackHandler<BailCas
             throw new IllegalStateException("Cannot handle callback");
         }
 
-        State currentCaseState = callback.getCaseDetails().getState();
+        String currentCaseState = callback.getCaseDetails().getState().toString();
 
         BailCase bailCase =
             callback
@@ -46,14 +52,19 @@ public class CurrentCaseStateUpdater implements PreSubmitCallbackHandler<BailCas
                 .getCaseData();
 
         if (bailCase.read(RECORD_DECISION_TYPE, String.class).orElse("")
-                .equals(DecisionType.CONDITIONAL_GRANT.toString())) {
-            currentCaseState = DECISION_CONDITIONAL_BAIL;
+            .equals(DecisionType.CONDITIONAL_GRANT.toString()) && (callback.getEvent() == Event.RECORD_THE_DECISION)) {
+            currentCaseState = DECISION_CONDITIONAL_BAIL.toString();
+        }
+        if (callback.getEvent().equals(Event.UPLOAD_SIGNED_DECISION_NOTICE)) {
+            //Setting the field to intermediate state in order to use it in the caseTypeTab FieldShowConditions
+            currentCaseState = IntermediateState.SIGNED_DECISION_NOTICE_UPLOADED.toString();
         }
 
         bailCase.write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, currentCaseState);
         bailCase.write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, currentCaseState);
         bailCase.write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, currentCaseState);
         bailCase.write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, currentCaseState);
+        bailCase.write(CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS, currentCaseState);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/EndApplicationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/EndApplicationHandler.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.END_APPLICATION_DATE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.END_APPLICATION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class EndApplicationHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    private final DateProvider dateProvider;
+
+    public EndApplicationHandler(
+        DateProvider dateProvider
+    ) {
+        this.dateProvider = dateProvider;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(END_APPLICATION);
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        System.out.println(dateProvider.now());
+        bailCase.write(END_APPLICATION_DATE, dateProvider.now().toString());
+
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/MoveApplicationToDecidedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/MoveApplicationToDecidedHandler.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT;
+
+@Component
+public class MoveApplicationToDecidedHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && callback.getEvent() == Event.MOVE_APPLICATION_TO_DECIDED;
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<BailCase> response = new PreSubmitCallbackResponse<>(bailCase);
+
+        Optional<Document> maybeUploadSignedDecision =
+            bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class);
+
+        if (maybeUploadSignedDecision.isEmpty()) {
+            response.addError("You must upload a signed decision notice before moving the application to decided.");
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -45,7 +45,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<BailCas
         List<Event> eventsToHandle = Lists.newArrayList(
             Event.SUBMIT_APPLICATION,
             Event.UPLOAD_BAIL_SUMMARY,
-            Event.UPLOAD_SIGNED_DECISION_NOTICE
+            Event.UPLOAD_SIGNED_DECISION_NOTICE,
+            Event.END_APPLICATION
         );
         return eventsToHandle;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.TRIBUNAL_DOCUMENTS_WITH_METADATA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SIGNED_DECISION_NOTICE_METADATA;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
@@ -60,19 +64,24 @@ public class UploadSignedDecisionNoticeHandler implements PreSubmitCallbackHandl
                 .getCaseData();
 
         Document maybeSignedDecisionNotice = bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)
-            .orElseThrow(() -> new IllegalStateException("signed decision notice is not present"));
+            .orElseThrow(() -> new IllegalStateException("signedDecisionNotice is not present"));
 
-        List<DocumentWithMetadata> signedDecisionNotice = new ArrayList<>();
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingTribunalDocuments =
+            bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA);
+
+        final List<IdValue<DocumentWithMetadata>> existingTribunalDocuments =
+            maybeExistingTribunalDocuments.orElse(Collections.emptyList());
+
+        List<IdValue<DocumentWithMetadata>> allTribunalDocuments = new ArrayList<>();
+
         documentReceiver.tryReceive(
                 new DocumentWithDescription(maybeSignedDecisionNotice, ""), DocumentTag.SIGNED_DECISION_NOTICE)
-            .ifPresent(signedDecisionNotice::add);
+            .ifPresent(signedDecisionNoticeDocumentWithMetadata ->
+                           allTribunalDocuments.addAll(documentsAppender.append(
+                               existingTribunalDocuments, List.of(signedDecisionNoticeDocumentWithMetadata)
+            )));
 
-        bailCase.clear(SIGNED_DECISION_NOTICE_METADATA);
-
-        List<IdValue<DocumentWithMetadata>> newSignedDecisionNotice =
-            documentsAppender.append(new ArrayList<>(), signedDecisionNotice);
-
-        bailCase.write(SIGNED_DECISION_NOTICE_METADATA, newSignedDecisionNotice);
+        bailCase.write(TRIBUNAL_DOCUMENTS_WITH_METADATA, allTribunalDocuments);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
@@ -13,13 +13,14 @@ public class DocumentTagTest {
         assertEquals("applicationSubmission", DocumentTag.APPLICATION_SUBMISSION.toString());
         assertEquals("uploadBailSummary", DocumentTag.BAIL_SUMMARY.toString());
         assertEquals("signedDecisionNotice", DocumentTag.SIGNED_DECISION_NOTICE.toString());
+        assertEquals("bailDecisionUnsigned", DocumentTag.BAIL_DECISION_UNSIGNED.toString());
         assertEquals("", DocumentTag.NONE.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(5, DocumentTag.values().length);
+        assertEquals(6, DocumentTag.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -15,11 +15,12 @@ public class EventTest {
         assertEquals("recordTheDecision", Event.RECORD_THE_DECISION.toString());
         assertEquals("uploadSignedDecisionNotice", Event.UPLOAD_SIGNED_DECISION_NOTICE.toString());
         assertEquals("addCaseNote", Event.ADD_CASE_NOTE.toString());
+        assertEquals("moveApplicationToDecided", Event.MOVE_APPLICATION_TO_DECIDED.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(8, Event.values().length);
+        assertEquals(9, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateStateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/IntermediateStateTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class IntermediateStateTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("signedDecisionNoticeUploaded", IntermediateState.SIGNED_DECISION_NOTICE_UPLOADED.toString());
+        assertEquals("unknown", State.UNKNOWN.toString());
+    }
+
+    @Test
+    void fail_if_changes_needed_after_modifying_class() {
+        assertEquals(2, IntermediateState.values().length);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StateTest.java
@@ -14,7 +14,6 @@ public class StateTest {
         assertEquals("applicationEnded", State.APPLICATION_ENDED.toString());
         assertEquals("applicationSubmitted", State.APPLICATION_SUBMITTED.toString());
         assertEquals("bailSummaryUploaded", State.BAIL_SUMMARY_UPLOADED.toString());
-        assertEquals("signedDecisionNoticeUploaded", State.SIGNED_DECISION_NOTICE_UPLOADED.toString());
         assertEquals("decisionDecided", State.DECISION_DECIDED.toString());
         assertEquals("decisionConditionalBail", State.DECISION_CONDITIONAL_BAIL.toString());
         assertEquals("unknown", State.UNKNOWN.toString());
@@ -22,7 +21,7 @@ public class StateTest {
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(10, State.values().length);
+        assertEquals(9, State.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmationTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class EndApplicationConfirmationTest {
+    @Mock
+    private Callback<BailCase> callback;
+
+    private final EndApplicationConfirmation endApplicationConfirmation = new EndApplicationConfirmation();
+
+    @Test
+    void should_handle_only_valid_event() {
+        for (Event event: Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            boolean canHandle = endApplicationConfirmation.canHandle(callback);
+            if (event.equals(Event.END_APPLICATION)) {
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_throw_null_args() {
+        assertThatThrownBy(() -> endApplicationConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_handle_invalid_event() {
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPLICATION);
+        assertThatThrownBy(() -> endApplicationConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_set_confirmation_header_body() {
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION);
+        PostSubmitCallbackResponse response = endApplicationConfirmation
+            .handle(callback);
+        assertEquals("# You have ended the application", response.getConfirmationHeader().get());
+        assertThat(response.getConfirmationBody().get()).contains("#### What happens next\n\n");
+        assertThat(response.getConfirmationBody().get())
+            .contains("A notification has been sent to all parties. No further action is required.");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MoveApplicationToDecidedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MoveApplicationToDecidedConfirmationTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MoveApplicationToDecidedConfirmationTest {
+
+    @Mock private Callback<BailCase> callback;
+
+    @Mock private CaseDetails<BailCase> caseDetails;
+    private MoveApplicationToDecidedConfirmation moveApplicationToDecidedConfirmation;
+
+    @BeforeEach
+    public void setUp() {
+        moveApplicationToDecidedConfirmation = new MoveApplicationToDecidedConfirmation();
+        when(callback.getEvent()).thenReturn(Event.MOVE_APPLICATION_TO_DECIDED);
+    }
+
+    @Test
+    void should_not_allow_null_args() {
+        assertThatThrownBy(() -> moveApplicationToDecidedConfirmation.handle(null))
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_handle_invalid_callback() {
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION); //Invalid event for this handler
+
+        assertThatThrownBy(() -> moveApplicationToDecidedConfirmation.handle(callback)).isExactlyInstanceOf(
+            IllegalStateException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE;
@@ -45,10 +46,11 @@ class CurrentCaseStateUpdaterTest {
         new CurrentCaseStateUpdater();
 
     @Test
-    void should_set_case_building_ready_for_submission_flag_to_yes() {
+    void should_set_variables_to_appropriate_states() {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPLICATION);
 
         for (State state : State.values()) {
 
@@ -61,10 +63,10 @@ class CurrentCaseStateUpdaterTest {
             assertNotNull(callbackResponse);
             assertEquals(bailCase, callbackResponse.getData());
 
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state);
-            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state);
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state.toString());
+            verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state.toString());
             reset(bailCase);
         }
     }
@@ -122,21 +124,24 @@ class CurrentCaseStateUpdaterTest {
 
     @Test
     void should_update_state_to_conditionalGrant_based_on_decision_type() {
+        State state = DECISION_CONDITIONAL_BAIL;
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(caseDetails.getState()).thenReturn(state);
         when(bailCase.read(RECORD_DECISION_TYPE, String.class)).thenReturn(Optional.of("conditionalGrant"));
+        when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
 
         PreSubmitCallbackResponse<BailCase> response = currentCaseStateUpdater
             .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
-        State state = DECISION_CONDITIONAL_BAIL;
         assertNotNull(response);
         assertEquals(bailCase, response.getData());
 
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state);
-        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state);
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state.toString());
+        verify(bailCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS, state.toString());
         reset(bailCase);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/EndApplicationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/EndApplicationHandlerTest.java
@@ -1,0 +1,121 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class EndApplicationHandlerTest {
+
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+    @Mock private DateProvider dateProvider;
+
+    private final LocalDate now = LocalDate.now();
+
+    private EndApplicationHandler endApplicationHandler;
+
+    @BeforeEach
+    public void setUp() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        endApplicationHandler = new EndApplicationHandler(dateProvider);
+        when(dateProvider.now()).thenReturn(now);
+    }
+
+
+
+    @Test
+    void set_end_application_date() {
+        PreSubmitCallbackResponse<BailCase> response = endApplicationHandler.handle(
+            PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
+            callback
+        );
+
+        assertNotNull(response);
+        assertEquals(bailCase, response.getData());
+        verify(bailCase).write(BailCaseFieldDefinition.END_APPLICATION_DATE, now.toString());
+    }
+
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> endApplicationHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPLICATION);
+        assertThatThrownBy(() -> endApplicationHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = endApplicationHandler.canHandle(callbackStage, callback);
+
+                assertThat(canHandle).isEqualTo(
+                    callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                        && event.equals(Event.END_APPLICATION)
+                );
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> endApplicationHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> endApplicationHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> endApplicationHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> endApplicationHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/MoveApplicationToDecidedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/MoveApplicationToDecidedHandlerTest.java
@@ -1,0 +1,138 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class MoveApplicationToDecidedHandlerTest {
+
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+    @Mock private Document exampleDocument;
+
+    private MoveApplicationToDecidedHandler moveApplicationToDecidedHandler;
+
+    private String callbackErrorMessage =
+        "You must upload a signed decision notice before moving the application to decided.";
+
+
+    @BeforeEach
+    public void setUp() {
+        this.moveApplicationToDecidedHandler = new MoveApplicationToDecidedHandler();
+    }
+
+    @Test
+    void should_not_move_application_to_decided_as_no_decision_notice_uploaded() {
+
+        when(callback.getEvent()).thenReturn(Event.MOVE_APPLICATION_TO_DECIDED);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            moveApplicationToDecidedHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(bailCase, callbackResponse.getData());
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1).containsOnly(callbackErrorMessage);
+    }
+
+    @Test
+    void should_move_application_to_decided() {
+
+        when(callback.getEvent()).thenReturn(Event.MOVE_APPLICATION_TO_DECIDED);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+
+        when(bailCase.read(BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class))
+            .thenReturn(Optional.of(exampleDocument));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            moveApplicationToDecidedHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(bailCase, callbackResponse.getData());
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(0);
+    }
+
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = moveApplicationToDecidedHandler.canHandle(callbackStage, callback);
+                if (callbackStage == ABOUT_TO_START
+                    && (callback.getEvent() == Event.MOVE_APPLICATION_TO_DECIDED)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(
+            () -> moveApplicationToDecidedHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> moveApplicationToDecidedHandler
+            .canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> moveApplicationToDecidedHandler
+            .canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> moveApplicationToDecidedHandler
+            .handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> moveApplicationToDecidedHandler
+            .handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -104,7 +104,8 @@ class SendNotificationHandlerTest {
                     Arrays.asList(
                         Event.SUBMIT_APPLICATION,
                         Event.UPLOAD_BAIL_SUMMARY,
-                        Event.UPLOAD_SIGNED_DECISION_NOTICE
+                        Event.UPLOAD_SIGNED_DECISION_NOTICE,
+                        Event.END_APPLICATION
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
* Ria 5345 uploaded bail summary notification email (#79)

* RIA-5610: Added delegator to send requests to Documents API & Notific… (#67)

* RIA-5610: Added delegator to send requests to Documents API & Notifications API

- Added handler for document generation on Application Submission.
- Added missing CaseFieldDefinitions.
- Added relevant tests.

* RIA-5610: Suppressing vulnerabilities

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5455 Adding case state updater to allow state based filtering wit… (#64)

* RIA-5455 Adding case state updater to allow state based filtering within CCD

* RIA-5455 Adding CVEs to suppression prior to fixing in separate ticket

Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>

* RIA-5584: Added Notification Handler and Notification API details (#68)

* RIA-5584: Added Notification Handler and Notification API details

* RIA-5584: Added unit tests for NotificationApiSender

* RIA-5584: Fixed CVE-2016-1000027 vulnerability issue

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5345 Added upload bail summar event to send handler

* Added suppression CVE-2022-22968

* Minor change

Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>
Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>
Co-authored-by: Dbarnes-v1 <99024336+Dbarnes-v1@users.noreply.github.com>

* RIA-5652: Added new states for started by LR and HO (#82)

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5488 (#81)

* RIA-5488 Adding aboutToStart handler for the Record Decision event. Used for pre-populating data

* RIA-5488 Fixing formatting of pre-populated text

* Ria 5491 ss not needed bail refused (#78)

* RIA-5491 Add new field "reasonForRefusalDetails", handler for bail refusal, and post-event confirmation

* RIA-5491 Add tests for BailDecisionRecordedConfirmation and BailRefusedAppender

* RIA-5491 Delete BailRefusedAppender and test

* RIA-5490 Bail transfer field pre-population  (#83)

* Added prepopulation for bail transfer directions

* Added prepopulation for bail transfer directions

* checkstyle fix

* checkstyle fix 2

* Ria 5488 (#85)

* RIA-5488 Adding aboutToStart handler for the Record Decision event. Used for pre-populating data

* RIA-5488 Fixing formatting of pre-populated text

* RIA-5488 - QA Fix - Fixing wording of pre-populated text.

* RIA-5491 Small content change (#86)

* RIA-5491 Small content change

* RIA-5488 Small content change

* RIA-5490 Small content change

* RIA-5682 Address Vulnerability Issues (#70)

* fixing suppressions
Upgraded spring framework security and retry
Upgraded spring framework
Upgraded jackson
Upgraded spring boot version

* Added suppressions
Upgraded Springfox
Upgraded plugins

* Migrated SpringFox to OpenAPI v3

* Upgraded serenity

* Removed comments

* RIA-5493 Add Secretary of State refusal reasons (#87)

* RIA-5519 Add UploadSignedDecisionNotice event (#88)

* RIA-5519 Add pre- and post- handlers, and add to DocumentTag, Event, CaseField and State for uploadSignedDecisionNotice

* RIA-5519 Change test name

* RIA-5519 Fix State test to add Record The Decision's value assertion

* RIA-5519 Turn text into link (#93)

* RIA-5538: Added handlers to append case notes (#92)

- Added new event.
- Modified UserInfo to hold more details like name.
- Added tests.

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5520 Post-signed notice overview screens (#97)

* definitions and handler for decision type

* handller, definitions and decision enums updated

* Adding decision date population

* updated handler and added unit test, plus 2 new states

* Removing record the decision state as no longer needed

* Removed record the decision from test

* Changed StateTest to pass

* RIA-5538: Fix logged-in user's first name (#98)

* RIA-5538: Fix logged-in user's first name

* RIA-5538: Suppress vulnerability CVE-2022-25647

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5495: Update state in currentStateUpdater for Condition Grant decision type (#100)

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5610: Create Applicant Documents Collection (#103)

-  Added bail evidence and bail submission document.

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5561 Handle notification for Upload Signed Decision Notice (#102)

* RIA-5496 added document handler for record decision event. (#101)

* RIA-5496 added document handler for record decision event.

* Added condition for bail list field

* Tribunal documents with metadata name change

* Bail pi25 ip conflicts (#105)

* Merging dev branch to master (#89)

* Ria 5345 uploaded bail summary notification email (#79)

* RIA-5610: Added delegator to send requests to Documents API & Notific… (#67)

* RIA-5610: Added delegator to send requests to Documents API & Notifications API

- Added handler for document generation on Application Submission.
- Added missing CaseFieldDefinitions.
- Added relevant tests.

* RIA-5610: Suppressing vulnerabilities

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5455 Adding case state updater to allow state based filtering wit… (#64)

* RIA-5455 Adding case state updater to allow state based filtering within CCD

* RIA-5455 Adding CVEs to suppression prior to fixing in separate ticket

Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>

* RIA-5584: Added Notification Handler and Notification API details (#68)

* RIA-5584: Added Notification Handler and Notification API details

* RIA-5584: Added unit tests for NotificationApiSender

* RIA-5584: Fixed CVE-2016-1000027 vulnerability issue

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5345 Added upload bail summar event to send handler

* Added suppression CVE-2022-22968

* Minor change

Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>
Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>
Co-authored-by: Dbarnes-v1 <99024336+Dbarnes-v1@users.noreply.github.com>

* RIA-5652: Added new states for started by LR and HO (#82)

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5488 (#81)

* RIA-5488 Adding aboutToStart handler for the Record Decision event. Used for pre-populating data

* RIA-5488 Fixing formatting of pre-populated text

* Ria 5491 ss not needed bail refused (#78)

* RIA-5491 Add new field "reasonForRefusalDetails", handler for bail refusal, and post-event confirmation

* RIA-5491 Add tests for BailDecisionRecordedConfirmation and BailRefusedAppender

* RIA-5491 Delete BailRefusedAppender and test

* RIA-5490 Bail transfer field pre-population  (#83)

* Added prepopulation for bail transfer directions

* Added prepopulation for bail transfer directions

* checkstyle fix

* checkstyle fix 2

* Ria 5488 (#85)

* RIA-5488 Adding aboutToStart handler for the Record Decision event. Used for pre-populating data

* RIA-5488 Fixing formatting of pre-populated text

* RIA-5488 - QA Fix - Fixing wording of pre-populated text.

* RIA-5491 Small content change (#86)

* RIA-5491 Small content change

* RIA-5488 Small content change

* RIA-5490 Small content change

* RIA-5682 Address Vulnerability Issues (#70)

* fixing suppressions
Upgraded spring framework security and retry
Upgraded spring framework
Upgraded jackson
Upgraded spring boot version

* Added suppressions
Upgraded Springfox
Upgraded plugins

* Migrated SpringFox to OpenAPI v3

* Upgraded serenity

* Removed comments

* RIA-5493 Add Secretary of State refusal reasons (#87)

Co-authored-by: ThomasKKC <99262639+ThomasKKC@users.noreply.github.com>
Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>
Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>
Co-authored-by: Dbarnes-v1 <99024336+Dbarnes-v1@users.noreply.github.com>
Co-authored-by: Marcello Fabbri <56549133+Marcellofabbri@users.noreply.github.com>
Co-authored-by: Ryan-Nesbitt <95298094+Ryan-Nesbitt@users.noreply.github.com>

* Updates to fix deployment pipeline (#99)

* Updates to fix deployment pipeline

* Suppress vulnerabilities

* Updates to fix pipeline issues

* Bumping chart version

* Updates to fix deployment issues

* Updates to fix deployment issues

* Updates to fix deployment issues

* Updates to fix terraform issue

* Updates to fix the terraform version

Co-authored-by: hmcts-jenkins-d-to-i <62423932+hmcts-jenkins-d-to-i[bot]@users.noreply.github.com>

Co-authored-by: ThomasKKC <99262639+ThomasKKC@users.noreply.github.com>
Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>
Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>
Co-authored-by: Dbarnes-v1 <99024336+Dbarnes-v1@users.noreply.github.com>
Co-authored-by: Marcello Fabbri <56549133+Marcellofabbri@users.noreply.github.com>
Co-authored-by: Ryan-Nesbitt <95298094+Ryan-Nesbitt@users.noreply.github.com>
Co-authored-by: hmcts-jenkins-d-to-i <62423932+hmcts-jenkins-d-to-i[bot]@users.noreply.github.com>

* RIA-5495 post-record decision overview page (#109)

* 5495 commit

* fix checkstyle

* RIA-5519 Refactor UploadSignedDecisionNoticeHandler (#110)

* RIA-5519 Refactor UploadSignedDecisionNoticeHandler

* RIA-5519 Refactor + codestyle fix

* RIA-5207: End Application Handler and Confirmation (#111)

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* RIA-5532: Added intermediate state for uploadSignedDecisionNotice (#112)

- Updated current state to new intermediate state for Event.UPLOAD_SIGNED_DECISION_NOTICE.
- Changed the currentCaseStateVisibleTo* variables type to String from State.

Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>

* Ria 5532 move to decided (#113)

* RIA-5532

    - Adding Move application to decided event
    - Adding validation to require a signed decision notice before event can start

* RIA-5532

    - Adding event based validation into CurrentCaseStateUpdater

* RIA-5214 Add END_APPLICATION to events to handle for notifications (#114)

* Added document tag (#115)

Co-authored-by: ThomasKKC <99262639+ThomasKKC@users.noreply.github.com>
Co-authored-by: NehaAggarwal <nehaaggarwal.1987@gmail.com>
Co-authored-by: Neha Aggarwal <neha.aggarwal@version1.com>
Co-authored-by: Dbarnes-v1 <99024336+Dbarnes-v1@users.noreply.github.com>
Co-authored-by: Marcello Fabbri <56549133+Marcellofabbri@users.noreply.github.com>
Co-authored-by: Ryan-Nesbitt <95298094+Ryan-Nesbitt@users.noreply.github.com>
Co-authored-by: hmcts-jenkins-d-to-i <62423932+hmcts-jenkins-d-to-i[bot]@users.noreply.github.com>

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
