### PR TITLE
Ria 5556 UI screens

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -23,7 +23,6 @@ def secrets = [
     secret('prof-ref-data-url', 'PROF_REF_DATA_URL'),
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
-    secret('submit-hearing-requirements-enabled', 'IA_SUBMIT_HEARING_REQUIREMENTS_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY')
 
   ]
@@ -42,13 +41,13 @@ withPipeline(type, product, component) {
 
   env.IA_CASE_DOCUMENTS_API_URL = "http://ia-case-documents-api-aat.service.core-compute-aat.internal/"
   env.IA_CASE_NOTIFICATIONS_API_URL = "http://ia-case-notifications-api-aat.service.core-compute-aat.internal/"
-  env.IA_TIMED_EVENT_SERVICE_URL = "http://ia-timed-event-service-aat.service.core-compute-aat.internal/"
-  env.IA_CASE_PAYMENTS_API_URL = "http://ia-case-payments-api-aat.service.core-compute-aat.internal/"
-  env.IA_HOME_OFFICE_INTEGRATION_API_URL = "http://ia-home-office-integration-api-aat.service.core-compute-aat.internal/"
   env.IA_IDAM_REDIRECT_URI = "https://ia-bail-case-api-aat.service.core-compute-aat.internal/oauth2/callback"
   env.CCD_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
   env.CCD_GW_URL = "http://dm-store-aat.service.core-compute-aat.internal"
-
+  env.DM_URL = "http://dm-store-aat.service.core-compute-aat.internal"
+  env.IA_TIMED_EVENT_SERVICE_URL = "http://ia-timed-event-service-aat.service.core-compute-aat.internal/"
+  env.IA_CASE_PAYMENTS_API_URL = "http://ia-case-payments-api-aat.service.core-compute-aat.internal/"
+  env.IA_HOME_OFFICE_INTEGRATION_API_URL = "http://ia-home-office-integration-api-aat.service.core-compute-aat.internal/"
   env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
   env.OPEN_ID_IDAM_URL = "https://idam-web-public.aat.platform.hmcts.net"
   env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -57,7 +57,6 @@ def secrets = [
     secret('prof-ref-data-url', 'PROF_REF_DATA_URL'),
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
-    secret('submit-hearing-requirements-enabled', 'IA_SUBMIT_HEARING_REQUIREMENTS_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
 
   ]
@@ -78,9 +77,6 @@ withNightlyPipeline(type, product, component) {
 
   env.IA_CASE_DOCUMENTS_API_URL = "http://ia-case-documents-api-aat.service.core-compute-aat.internal/"
   env.IA_CASE_NOTIFICATIONS_API_URL = "http://ia-case-notifications-api-aat.service.core-compute-aat.internal/"
-  env.IA_TIMED_EVENT_SERVICE_URL = "http://ia-timed-event-service-aat.service.core-compute-aat.internal/"
-  env.IA_CASE_PAYMENTS_API_URL = "http://ia-case-payments-api-aat.service.core-compute-aat.internal/"
-  env.IA_HOME_OFFICE_INTEGRATION_API_URL = "http://ia-home-office-integration-api-aat.service.core-compute-aat.internal/"
   env.IA_IDAM_REDIRECT_URI = "https://ia-bail-case-api-aat.service.core-compute-aat.internal/oauth2/callback"
   env.CCD_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
   env.CCD_GW_URL = "http://dm-store-aat.service.core-compute-aat.internal"
@@ -88,7 +84,6 @@ withNightlyPipeline(type, product, component) {
   env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
   env.OPEN_ID_IDAM_URL = "https://idam-web-public.aat.platform.hmcts.net"
   env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-  env.IS_SAVE_AND_CONTINUE_ENABLED = "false"
 
   loadVaultSecrets(secrets)
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -13,6 +13,47 @@ properties([
   pipelineTriggers([[$class: 'GitHubPushTrigger']])
 ])
 
+def secrets = [
+  'ia-${env}': [
+
+    secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
+    secret('idam-secret', 'IA_IDAM_SECRET'),
+    secret('s2s-secret', 'IA_S2S_SECRET'),
+    secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
+    secret('prof-ref-data-url', 'PROF_REF_DATA_URL'),
+    secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+
+  ]
+]
+
+static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
+  [$class     : 'AzureKeyVaultSecret',
+   secretType : 'Secret',
+   name       : secretName,
+   version    : '',
+   envVariable: envVar
+  ]
+}
+
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
 
+  env.IA_CASE_DOCUMENTS_API_URL = "http://ia-case-documents-api-aat.service.core-compute-aat.internal/"
+  env.IA_CASE_NOTIFICATIONS_API_URL = "http://ia-case-notifications-api-aat.service.core-compute-aat.internal/"
+  env.IA_IDAM_REDIRECT_URI = "https://ia-bail-case-api-aat.service.core-compute-aat.internal/oauth2/callback"
+  env.CCD_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
+  env.CCD_GW_URL = "http://dm-store-aat.service.core-compute-aat.internal"
+  env.DM_URL = "http://dm-store-aat.service.core-compute-aat.internal"
+  env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
+  env.OPEN_ID_IDAM_URL = "https://idam-web-public.aat.platform.hmcts.net"
+  env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+
+  loadVaultSecrets(secrets)
+
+  after('functionalTest:preview') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+  }
+
+  after('functionalTest:aat') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+  }
 }

--- a/charts/ia-bail-case-api/Chart.yaml
+++ b/charts/ia-bail-case-api/Chart.yaml
@@ -6,6 +6,7 @@ home: https://github.com/hmcts/ia-bail-case-api
 version: 0.0.4
 maintainers:
   - name: Immigration & Asylum Team
+    email: ImmigrationandAsylum@HMCTS.NET
 dependencies:
   - name: java
     version: 3.7.2

--- a/charts/ia-bail-case-api/values.preview.template.yaml
+++ b/charts/ia-bail-case-api/values.preview.template.yaml
@@ -3,15 +3,27 @@ java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   environment:
+    CCD_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    CCD_GW_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    DM_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IA_IDAM_REDIRECT_URI: "https://ia-bail-case-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback"
     IDAM_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     OPEN_ID_IDAM_URL: "https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net"
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    PROF_REF_DATA_URL: "http://rd-professional-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IA_CASE_DOCUMENTS_API_URL: "http://ia-case-documents-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/"
+    IA_CASE_NOTIFICATIONS_API_URL: "http://ia-case-notifications-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/"
   keyVaults:
     ia:
       secrets:
+        - docmosis-enabled
+        - em-stitching-enabled
+        - system-username
+        - system-password
         - idam-client-id
         - idam-secret
         - s2s-secret
         - s2s-microservice
         - prof-ref-data-url
+        - launch-darkly-sdk-key
 

--- a/charts/ia-bail-case-api/values.yaml
+++ b/charts/ia-bail-case-api/values.yaml
@@ -1,15 +1,12 @@
 java:
-  applicationPort: 4550
+  applicationPort: 8099
   image: 'hmctspublic.azurecr.io/ia/ia-bail-case-api:latest'
   ingressHost: ia-bail-case-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   aadIdentityName: ia
-#  Uncomment once the vault containing the app insights key has been set up
-#  keyVaults:
-#    rpe:
-#      secrets:
-#        - name: AppInsightsInstrumentationKey
-#          alias: azure.application-insights.instrumentation-key
   environment:
+    CCD_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    CCD_GW_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    DM_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     IA_IDAM_REDIRECT_URI: "https://ia-bail-case-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback"
     IDAM_URL: "https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net"
     OPEN_ID_IDAM_URL: "https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net"
@@ -19,11 +16,18 @@ java:
     IA_CASE_NOTIFICATIONS_API_URL: "http://ia-case-notifications-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/"
   keyVaults:
     ia:
+      resourceGroup: ia
       secrets:
+        - docmosis-enabled
+        - em-stitching-enabled
+        - system-username
+        - system-password
         - idam-client-id
         - idam-secret
         - s2s-secret
         - s2s-microservice
         - prof-ref-data-url
+        - launch-darkly-sdk-key
+        - AppInsightsInstrumentationKey
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,20 +8,54 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
+    networks:
+      - compose_default
     image: hmcts/ia-bail-case-api
     container_name: ia-bail-case-api
     environment:
+      JAVA_OPTS:
       # these environment variables are used by java-logging library
-      - ROOT_APPENDER
-      - JSON_CONSOLE_PRETTY_PRINT
-      - ROOT_LOGGING_LEVEL
-      - REFORM_SERVICE_TYPE
-      - REFORM_SERVICE_NAME
-      - REFORM_TEAM
-      - REFORM_ENVIRONMENT
-      - LOGBACK_DATE_FORMAT
-      - LOGBACK_REQUIRE_THREAD
-      - LOGBACK_REQUIRE_ALERT_LEVEL=false
-      - LOGBACK_REQUIRE_ERROR_CODE=false
+      JSON_CONSOLE_PRETTY_PRINT:
+      ROOT_APPENDER:
+      ROOT_LOGGING_LEVEL:
+      REFORM_SERVICE_TYPE:
+      REFORM_SERVICE_NAME:
+      REFORM_TEAM:
+      REFORM_ENVIRONMENT:
+      LOGBACK_DATE_FORMAT:
+      LOGBACK_REQUIRE_THREAD:
+      LOGBACK_REQUIRE_ALERT_LEVEL: "false"
+      LOGBACK_REQUIRE_ERROR_CODE: "false"
+      # Application environment variables
+      CCD_GW_URL: http://ccd-api-gateway-web:3453
+      IDAM_URL: http://idam-api:8080
+      IA_IDAM_REDIRECT_URI: http://idam-api
+      S2S_URL: http://service-auth-provider-api:8080
+      CCD_URL: http://ccd-data-store-api:4452
+      DM_URL: http://dm-store:8080
+      IA_CASE_DOCUMENTS_API_URL: http://ia-case-documents-api:8092
+      IA_CASE_NOTIFICATIONS_API_URL: http://ia-case-notifications-api:8093
+      IA_IDAM_CLIENT_ID:
+      IA_IDAM_SECRET:
+      IA_S2S_MICROSERVICE:
+      IA_S2S_SECRET:
+      IA_SYSTEM_USERNAME:
+      IA_SYSTEM_PASSWORD:
+      IA_EM_STITCHING_ENABLED:
+      IA_DOCMOSIS_ENABLED:
+    external_links:
+      - idam-api
+      - dm-store
+      - ccd-shared-database
+      - ccd-api-gateway-web
+      - ccd-data-store-api
+      - service-auth-provider-api
+      - stitching-api
+      - ia-case-documents-api
+      - ia-case-notifications-api
     ports:
-      - $SERVER_PORT:$SERVER_PORT
+      - ${SERVER_PORT:-8099}:${SERVER_PORT:-8099}
+networks:
+  compose_default:
+    external: true
+

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -24,20 +24,4 @@ data "azurerm_key_vault" "ia_key_vault" {
   resource_group_name = "${local.key_vault_name}"
 }
 
-module "ia_bail_case_api_database_11" {
-  source             = "git@github.com:hmcts/cnp-module-postgres?ref=master"
-  product            = "${var.product}-${var.component}-postgres-11-db"
-  location           = "${var.location}"
-  env                = "${var.env}"
-  database_name      = "${var.postgresql_database_name}"
-  postgresql_user    = "${var.postgresql_user}"
-  postgresql_version = "11"
-  common_tags        = "${merge(var.common_tags, map("lastUpdated", "${timestamp()}"))}"
-  subscription       = "${var.subscription}"
-}
 
-resource "azurerm_key_vault_secret" "POSTGRES-PASS-11" {
-  name         = "${var.component}-POSTGRES-PASS-11"
-  value        = module.ia_bail_case_api_database_11.postgresql_password
-  key_vault_id = data.azurerm_key_vault.ia_key_vault.id
-}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -44,10 +44,3 @@ variable "log_level_ia" {
   default = "INFO"
 }
 
-variable "postgresql_database_name" {
-  default = "ia_bail_case_api"
-}
-
-variable "postgresql_user" {
-  default = "ia_bail_case_api"
-}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -324,7 +324,11 @@ public enum BailCaseFieldDefinition {
     TRIBUNAL_DOCUMENTS_WITH_METADATA(
         "tribunalDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     END_APPLICATION_DATE(
-        "endApplicationDate", new TypeReference<String>(){})
+        "endApplicationDate", new TypeReference<String>(){}),
+    END_APPLICATION_OUTCOME(
+        "endApplicationOutcome", new TypeReference<String>(){}),
+    END_APPLICATION_REASONS(
+        "endApplicationReasons", new TypeReference<String>(){}),
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -297,6 +297,14 @@ public enum BailCaseFieldDefinition {
         "addCaseNoteDocument", new TypeReference<Document>(){}),
     CASE_NOTES(
         "caseNotes", new TypeReference<List<IdValue<CaseNote>>>(){}),
+    SEND_DIRECTION_DESCRIPTION(
+        "sendDirectionDescription", new TypeReference<String>(){}),
+    SEND_DIRECTION_LIST(
+        "sendDirectionList", new TypeReference<String>(){}),
+    DATE_OF_COMPLIANCE(
+        "dateOfCompliance", new TypeReference<String>(){}),
+    DIRECTION(
+        "directions", new TypeReference<List<IdValue<Direction>>>(){}),
     REASON_FOR_REFUSAL_DETAILS(
         "reasonForRefusalDetails", new TypeReference<String>(){}),
     TRIBUNAL_REFUSAL_REASON(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.w3c.dom.stylesheets.LinkStyle;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+@EqualsAndHashCode
+@ToString
+public class Direction {
+
+    private String directionDescription;
+    private String directionList;
+    private String dateOfCompliance;
+    private String user;
+    private String dateAdded;
+
+
+    private Direction() {
+    }
+
+    public Direction(
+        String directionDescription,
+        String directionList,
+        String dateOfCompliance,
+        String user,
+        String dateAdded
+    ) {
+        this.directionDescription = requireNonNull(directionDescription);
+        this.directionList = requireNonNull(directionList);
+        this.dateOfCompliance = requireNonNull(dateOfCompliance);
+        this.user = requireNonNull(user);
+        this.dateAdded = requireNonNull(dateAdded);
+    }
+
+
+    public String getDirectionDescription() {
+        return requireNonNull(directionDescription);
+    }
+
+    public String getDirectionList() {
+        return requireNonNull(directionList);
+    }
+
+    public String getDateOfCompliance() {
+        return requireNonNull(dateOfCompliance);
+    }
+
+    public String getUser() {
+        return requireNonNull(user);
+    }
+
+    public String getDateAdded() {
+        return requireNonNull(dateAdded);
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -2,10 +2,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.w3c.dom.stylesheets.LinkStyle;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
-
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -13,49 +9,42 @@ import static java.util.Objects.requireNonNull;
 @ToString
 public class Direction {
 
-    private String directionDescription;
-    private String directionList;
+    private String sendDirectionDescription;
+    private String sendDirectionList;
     private String dateOfCompliance;
-    private String user;
-    private String dateAdded;
+    private String dateSent;
 
 
     private Direction() {
     }
 
     public Direction(
-        String directionDescription,
-        String directionList,
+        String sendDirectionDescription,
+        String sendDirectionList,
         String dateOfCompliance,
-        String user,
-        String dateAdded
+        String dateSent
     ) {
-        this.directionDescription = requireNonNull(directionDescription);
-        this.directionList = requireNonNull(directionList);
+        this.sendDirectionDescription = requireNonNull(sendDirectionDescription);
+        this.sendDirectionList = requireNonNull(sendDirectionList);
         this.dateOfCompliance = requireNonNull(dateOfCompliance);
-        this.user = requireNonNull(user);
-        this.dateAdded = requireNonNull(dateAdded);
+        this.dateSent = requireNonNull(dateSent);
     }
 
 
-    public String getDirectionDescription() {
-        return requireNonNull(directionDescription);
+    public String getSendDirectionDescription() {
+        return requireNonNull(sendDirectionDescription);
     }
 
-    public String getDirectionList() {
-        return requireNonNull(directionList);
+    public String getSendDirectionList() {
+        return requireNonNull(sendDirectionList);
     }
 
     public String getDateOfCompliance() {
         return requireNonNull(dateOfCompliance);
     }
 
-    public String getUser() {
-        return requireNonNull(user);
-    }
-
-    public String getDateAdded() {
-        return requireNonNull(dateAdded);
+    public String getDateSent() {
+        return requireNonNull(dateSent);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -12,6 +12,7 @@ public enum Event {
     RECORD_THE_DECISION("recordTheDecision"),
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
+    SEND_DIRECTION("sendDirection"),
     MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),
 
     @JsonEnumDefaultValue

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -31,7 +31,7 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
             "### What happens next\n\n"
                     + "You can see the status of the direction in the [directions tab](/case/IA/Bail/"
                 + callback.getCaseDetails().getId()
-                + "#Case%20notes)."
+                + "#Directions)."
         );
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+import static java.util.Objects.requireNonNull;
+
+@Component
+public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(Callback<BailCase> callback) {
+        requireNonNull(callback, "callback must not be null");
+        return (callback.getEvent() == Event.SEND_DIRECTION);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationBody(
+            "### What happens next\n\n"
+                    + "You can see the status of the direction in the [directions tab](/case/IA/Bail/"
+                + callback.getCaseDetails().getId()
+                + "#Case%20notes)."
+        );
+
+        postSubmitResponse.setConfirmationHeader("# You have sent a direction");
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
@@ -4,12 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.RECORD_DECISION_TYPE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State.DECISION_CONDITIONAL_BAIL;
 
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE;
 
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.RECORD_DECISION_TYPE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State.DECISION_CONDITIONAL_BAIL;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -48,7 +48,8 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<BailCas
     private List<Event> getEventsToHandle() {
         List<Event> eventsToHandle = Lists.newArrayList(
             Event.SUBMIT_APPLICATION,
-            Event.RECORD_THE_DECISION
+            Event.RECORD_THE_DECISION,
+            Event.END_APPLICATION
         );
         return eventsToHandle;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.CaseNote;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.Appender;
+
+
+@Component
+public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    private final Appender<Direction> directionAppender;
+    private final DateProvider dateProvider;
+    private final UserDetails userDetails;
+
+    public SendDirectionHandler(
+        Appender<Direction> directionAppender,
+        DateProvider dateProvider,
+        UserDetails userDetails
+    ) {
+        this.directionAppender = directionAppender;
+        this.dateProvider = dateProvider;
+        this.userDetails = userDetails;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_DIRECTION);
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        String directionDescription = bailCase
+                .read(SEND_DIRECTION_DESCRIPTION, String.class)
+                .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
+
+        String directionList = bailCase
+                .read(SEND_DIRECTION_LIST, String.class)
+                .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
+
+        String dateOfCompliance = bailCase
+                .read(DATE_OF_COMPLIANCE, String.class)
+                .orElseThrow(() -> new IllegalStateException("dateOfCompliance is not present"));
+
+
+        Optional<List<IdValue<Direction>>> maybeExistingDirections =
+            bailCase.read(DIRECTION);
+
+
+
+        final Direction newDirection = new Direction(
+            directionDescription,
+            directionList,
+            dateOfCompliance,
+            buildFullName(),
+            dateProvider.now().toString()
+        );
+
+
+        List<IdValue<Direction>> allDirections =
+            directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
+
+        bailCase.write(DIRECTION, allDirections);
+
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
+
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+    private String buildFullName() {
+        return userDetails.getForename()
+            + " "
+            + userDetails.getSurname();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -66,11 +66,11 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
                 .getCaseDetails()
                 .getCaseData();
 
-        String directionDescription = bailCase
+        String sendDirectionDescription = bailCase
                 .read(SEND_DIRECTION_DESCRIPTION, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
 
-        String directionList = bailCase
+        String sendDirectionList = bailCase
                 .read(SEND_DIRECTION_LIST, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
 
@@ -85,10 +85,9 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
 
         final Direction newDirection = new Direction(
-            directionDescription,
-            directionList,
+            sendDirectionDescription,
+            sendDirectionList,
             dateOfCompliance,
-            buildFullName(),
             dateProvider.now().toString()
         );
 
@@ -103,11 +102,5 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
-    }
-
-    private String buildFullName() {
-        return userDetails.getForename()
-            + " "
-            + userDetails.getSurname();
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,8 @@
+logging.level:
+  root: info
+  org.springframework.web: debug
+  uk.gov.hmcts: debug
+
+idam:
+  ia_system_user:
+    scope: "openid profile authorities"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 server:
-  port: ${PORT:4550}
+  port: ${PORT:8099}
 
 management:
   endpoint:
@@ -59,7 +59,7 @@ spring:
       client:
         provider:
           oidc:
-            issuer-uri: ${OPEN_ID  _IDAM_URL:http://127.0.0.1:5000}/o
+            issuer-uri: ${OPEN_ID_IDAM_URL:http://127.0.0.1:5000}/o
         registration:
           oidc:
             client-id: ${IA_IDAM_CLIENT_ID:ia}
@@ -70,27 +70,7 @@ spring:
   profiles:
     include:
       - hearingcentre-mapping
-#  datasource:
-#    driver-class-name: org.postgresql.Driver
-#    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}${DB_OPTIONS:}
-#    username: ${DB_USER_NAME}
-#    password: ${DB_PASSWORD}
-#    properties:
-#      charSet: UTF-8
-#    hikari:
-#      minimumIdle: 2
-#      maximumPoolSize: 10
-#      idleTimeout: 10000
-#      poolName: {to-be-defined}HikariCP
-#      maxLifetime: 7200000
-#      connectionTimeout: 30000
-#  jpa:
-#    properties:
-#      hibernate:
-#        jdbc:
-#          lob:
-#            # silence the 'wall-of-text' - unnecessary exception throw about blob types
-#            non_contextual_creation: true
+
 
 #OpenID
 idam:
@@ -102,9 +82,15 @@ idam:
     url: ${S2S_URL:http://127.0.0.1:4502}
   s2s-authorised:
     services: ${IA_S2S_AUTHORIZED_SERVICES:ccd,ccd_data,ccd_gw,ccd_ps,iac}
+  ia_system_user:
+    username: ${IA_SYSTEM_USERNAME:system-user}
+    password: ${IA_SYSTEM_PASSWORD:system-password}
+    scope: "openid profile authorities acr roles create-user manage-user search-user"
+
 azure:
   application-insights:
     instrumentation-key: ${rpe.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
+
 documentsApi:
   endpoint: ${IA_CASE_DOCUMENTS_API_URL:http://127.0.0.1:8092}
   aboutToSubmitPath: "/bail/ccdAboutToSubmit"
@@ -116,6 +102,9 @@ notificationsApi:
   ccdSubmittedPath: "/bail/ccdSubmitted"
 
 ### dependency configuration
+ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}
+core_case_data_api_url: ${CCD_URL:http://127.0.0.1:4452}
+document_management.url: ${DM_URL:http://127.0.0.1:4506}
 idam.s2s-auth.totp_secret: ${IA_S2S_SECRET:AAAAAAAAAAAAAAAC}
 idam.s2s-auth.microservice: ${IA_S2S_MICROSERVICE:ia}
 idam.s2s-auth.url: ${S2S_URL:http://127.0.0.1:4502}
@@ -126,3 +115,8 @@ prof.ref.data.path.org.organisation: ${PROF_REF_DATA_ORG_ORGANISATION_PATH:/refd
 
 featureFlag:
   isDocumentGenerationEnabled: ${IA_DOCUMENT_GENERATION_ENABLED:false}
+
+launchDarkly:
+  sdkKey: ${LAUNCH_DARKLY_SDK_KEY:sdk-key}
+  connectionTimeout: 5000
+  socketTimeout: 5000

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,0 +1,25 @@
+spring:
+  cloud:
+    propertiesvolume:
+      prefixed: false
+      paths: /mnt/secrets/ia
+      aliases:
+        case-documents-api-url: IA_CASE_DOCUMENTS_API_URL
+        case-notifications-api-url: IA_CASE_NOTIFICATIONS_API_URL
+        docmosis-enabled: IA_DOCMOSIS_ENABLED
+        em-stitching-enabled: IA_EM_STITCHING_ENABLED
+        system-username: IA_SYSTEM_USERNAME
+        system-password: IA_SYSTEM_PASSWORD
+        idam-client-id: IA_IDAM_CLIENT_ID
+        idam-secret: IA_IDAM_SECRET
+        idam-redirect-uri: IA_IDAM_REDIRECT_URI
+        s2s-secret: idam.s2s-auth.totp_secret
+        s2s-microservice: IA_S2S_MICROSERVICE
+        ccd-url: CCD_URL
+        ccd-gw-url: CCD_GW_URL
+        dm-url: DM_URL
+        idam-url: IDAM_URL
+        s2s-url: S2S_URL
+        prof-ref-data-url: PROF_REF_DATA_URL
+        launch-darkly-sdk-key: LAUNCH_DARKLY_SDK_KEY
+        AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -57,7 +57,8 @@ public class GenerateDocumentHandlerTest {
                 boolean canHandle = generateDocumentHandler.canHandle(stage, callback);
                 if (stage.equals(PreSubmitCallbackStage.ABOUT_TO_SUBMIT) && Arrays.asList(
                     Event.SUBMIT_APPLICATION,
-                    Event.RECORD_THE_DECISION
+                    Event.RECORD_THE_DECISION,
+                    Event.END_APPLICATION
                 ).contains(event)) {
                     assertTrue(canHandle);
                 } else {
@@ -135,6 +136,22 @@ public class GenerateDocumentHandlerTest {
     public void should_handle_generate_document_signed_decision_notice_upload() {
         BailCase expectedBailCase = mock(BailCase.class);
         when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
+        when(documentGenerator.generate(callback)).thenReturn(expectedBailCase);
+
+        PreSubmitCallbackResponse response = generateDocumentHandler.handle(
+            PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
+            callback
+        );
+
+        assertNotNull(response);
+        assertEquals(expectedBailCase, response.getData());
+        verify(documentGenerator, times(1)).generate(callback);
+    }
+
+    @Test
+    public void should_handle_generate_document_end_application() {
+        BailCase expectedBailCase = mock(BailCase.class);
+        when(callback.getEvent()).thenReturn(Event.END_APPLICATION);
         when(documentGenerator.generate(callback)).thenReturn(expectedBailCase);
 
         PreSubmitCallbackResponse response = generateDocumentHandler.handle(

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -99,7 +99,7 @@ public class UploadSignedDecisionNoticeHandlerTest {
 
         when(documentsAppender.append(eq(new ArrayList<>()), eq(List.of(signedDecisionNoticeMetadata1))))
             .thenReturn(allTribunalDocs);
-
+        
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5556


### Change description ###
As an admin/judge 

I want to send the direction to parties,

So that they are aware of what to do next.

Acceptance Criteria

Send direction event can be triggered at application submitted, listing, bail summary, hearing state

Send direction should be shown in the event list as attached (send_direction_event.png)

Send direction event can be triggered in 2 ways.

 Select Send direction event from the dropdown
Click on Send a new direction link from the directions tab.
Then the following screens should appear in the order.

1) Direction details

     1.1 Free text box to explain the direction you are issuing

     1.2 Dropdown to select who are you giving the direction to ?

         Dropdown should have the values

                       Select a value
                       Legal representative
                       Home Office
                       Applicant
    1.3 By what date must they comply (Day Month Year) - Should be the future date

2) Check your answer

3) Success page

4) Updated overview page with the progress bar image as same state as before.

Direction details should be available in direction tab (will be covered in https://tools.hmcts.net/jira/browse/RIA-5557)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
