### PR TITLE
Ria 5556 UI screens

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -305,7 +305,7 @@ public enum BailCaseFieldDefinition {
         "sendDirectionList", new TypeReference<String>(){}),
     DATE_OF_COMPLIANCE(
         "dateOfCompliance", new TypeReference<String>(){}),
-    DIRECTION(
+    DIRECTIONS(
         "directions", new TypeReference<List<IdValue<Direction>>>(){}),
     REASON_FOR_REFUSAL_DETAILS(
         "reasonForRefusalDetails", new TypeReference<String>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -299,6 +299,14 @@ public enum BailCaseFieldDefinition {
         "addCaseNoteDocument", new TypeReference<Document>(){}),
     CASE_NOTES(
         "caseNotes", new TypeReference<List<IdValue<CaseNote>>>(){}),
+    SEND_DIRECTION_DESCRIPTION(
+        "sendDirectionDescription", new TypeReference<String>(){}),
+    SEND_DIRECTION_LIST(
+        "sendDirectionList", new TypeReference<String>(){}),
+    DATE_OF_COMPLIANCE(
+        "dateOfCompliance", new TypeReference<String>(){}),
+    DIRECTION(
+        "directions", new TypeReference<List<IdValue<Direction>>>(){}),
     REASON_FOR_REFUSAL_DETAILS(
         "reasonForRefusalDetails", new TypeReference<String>(){}),
     TRIBUNAL_REFUSAL_REASON(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -13,6 +13,7 @@ public class Direction {
     private String sendDirectionList;
     private String dateOfCompliance;
     private String dateSent;
+
     private Direction() {
     }
 
@@ -43,7 +44,6 @@ public class Direction {
 
     public String getDateSent() {
         return requireNonNull(dateSent);
-
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-
-
 import static java.util.Objects.requireNonNull;
 
 @EqualsAndHashCode

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.w3c.dom.stylesheets.LinkStyle;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+@EqualsAndHashCode
+@ToString
+public class Direction {
+
+    private String directionDescription;
+    private String directionList;
+    private String dateOfCompliance;
+    private String user;
+    private String dateAdded;
+
+
+    private Direction() {
+    }
+
+    public Direction(
+        String directionDescription,
+        String directionList,
+        String dateOfCompliance,
+        String user,
+        String dateAdded
+    ) {
+        this.directionDescription = requireNonNull(directionDescription);
+        this.directionList = requireNonNull(directionList);
+        this.dateOfCompliance = requireNonNull(dateOfCompliance);
+        this.user = requireNonNull(user);
+        this.dateAdded = requireNonNull(dateAdded);
+    }
+
+
+    public String getDirectionDescription() {
+        return requireNonNull(directionDescription);
+    }
+
+    public String getDirectionList() {
+        return requireNonNull(directionList);
+    }
+
+    public String getDateOfCompliance() {
+        return requireNonNull(dateOfCompliance);
+    }
+
+    public String getUser() {
+        return requireNonNull(user);
+    }
+
+    public String getDateAdded() {
+        return requireNonNull(dateAdded);
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -2,10 +2,6 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.w3c.dom.stylesheets.LinkStyle;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
-
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -13,49 +9,42 @@ import static java.util.Objects.requireNonNull;
 @ToString
 public class Direction {
 
-    private String directionDescription;
-    private String directionList;
+    private String sendDirectionDescription;
+    private String sendDirectionList;
     private String dateOfCompliance;
-    private String user;
-    private String dateAdded;
+    private String dateSent;
 
 
     private Direction() {
     }
 
     public Direction(
-        String directionDescription,
-        String directionList,
+        String sendDirectionDescription,
+        String sendDirectionList,
         String dateOfCompliance,
-        String user,
-        String dateAdded
+        String dateSent
     ) {
-        this.directionDescription = requireNonNull(directionDescription);
-        this.directionList = requireNonNull(directionList);
+        this.sendDirectionDescription = requireNonNull(sendDirectionDescription);
+        this.sendDirectionList = requireNonNull(sendDirectionList);
         this.dateOfCompliance = requireNonNull(dateOfCompliance);
-        this.user = requireNonNull(user);
-        this.dateAdded = requireNonNull(dateAdded);
+        this.dateSent = requireNonNull(dateSent);
     }
 
 
-    public String getDirectionDescription() {
-        return requireNonNull(directionDescription);
+    public String getSendDirectionDescription() {
+        return requireNonNull(sendDirectionDescription);
     }
 
-    public String getDirectionList() {
-        return requireNonNull(directionList);
+    public String getSendDirectionList() {
+        return requireNonNull(sendDirectionList);
     }
 
     public String getDateOfCompliance() {
         return requireNonNull(dateOfCompliance);
     }
 
-    public String getUser() {
-        return requireNonNull(user);
-    }
-
-    public String getDateAdded() {
-        return requireNonNull(dateAdded);
+    public String getDateSent() {
+        return requireNonNull(dateSent);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -3,12 +3,15 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 import org.w3c.dom.stylesheets.LinkStyle;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 
 import java.util.List;
 >>>>>>> 1c61fd5 (Backend for directions screen)
+=======
+>>>>>>> 3c3779b (RIA-5556 Tweak Direction object)
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -2,6 +2,13 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+<<<<<<< HEAD
+=======
+import org.w3c.dom.stylesheets.LinkStyle;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+
+import java.util.List;
+>>>>>>> 1c61fd5 (Backend for directions screen)
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -2,16 +2,8 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-import org.w3c.dom.stylesheets.LinkStyle;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 
-import java.util.List;
->>>>>>> 1c61fd5 (Backend for directions screen)
-=======
->>>>>>> 3c3779b (RIA-5556 Tweak Direction object)
+
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -13,7 +13,6 @@ public class Direction {
     private String sendDirectionList;
     private String dateOfCompliance;
     private String dateSent;
-
     private Direction() {
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -14,7 +14,6 @@ public class Direction {
     private String dateOfCompliance;
     private String dateSent;
 
-
     private Direction() {
     }
 
@@ -45,6 +44,7 @@ public class Direction {
 
     public String getDateSent() {
         return requireNonNull(dateSent);
+
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -12,6 +12,7 @@ public enum Event {
     RECORD_THE_DECISION("recordTheDecision"),
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
+    SEND_DIRECTION("sendDirection"),
     MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),
     UPLOAD_DOCUMENTS("uploadDocuments"),
     EDIT_DOCUMENTS("editDocuments"),

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -12,7 +12,7 @@ public enum Event {
     RECORD_THE_DECISION("recordTheDecision"),
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
-    SEND_DIRECTION("sendDirection"),
+    SEND_BAIL_DIRECTION("sendBailDirection"),
     MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),
     UPLOAD_DOCUMENTS("uploadDocuments"),
     EDIT_DOCUMENTS("editDocuments"),

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler
 
 import static java.util.Objects.requireNonNull;
 
-
 @Component
 public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,9 +8,6 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 
 @Component

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -16,7 +16,6 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
     public boolean canHandle(Callback<BailCase> callback) {
         requireNonNull(callback, "callback must not be null");
         return (callback.getEvent() == Event.SEND_BAIL_DIRECTION);
-
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,9 +8,6 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 @Component
 public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,6 +8,9 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 @Component
 public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
@@ -15,7 +18,7 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
     @Override
     public boolean canHandle(Callback<BailCase> callback) {
         requireNonNull(callback, "callback must not be null");
-        return (callback.getEvent() == Event.SEND_DIRECTION);
+        return (callback.getEvent() == Event.SEND_BAIL_DIRECTION);
     }
 
     @Override
@@ -35,6 +38,15 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
         );
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return postSubmitResponse;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,9 +8,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
+
 
 @Component
 public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
@@ -19,6 +17,7 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
     public boolean canHandle(Callback<BailCase> callback) {
         requireNonNull(callback, "callback must not be null");
         return (callback.getEvent() == Event.SEND_BAIL_DIRECTION);
+
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -39,15 +39,6 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");
 
-        BailCase bailCase =
-            callback
-                .getCaseDetails()
-                .getCaseData();
-
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
-
         return postSubmitResponse;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -16,6 +16,7 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
     public boolean canHandle(Callback<BailCase> callback) {
         requireNonNull(callback, "callback must not be null");
         return (callback.getEvent() == Event.SEND_BAIL_DIRECTION);
+
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -31,7 +31,7 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
             "### What happens next\n\n"
                     + "You can see the status of the direction in the [directions tab](/case/IA/Bail/"
                 + callback.getCaseDetails().getId()
-                + "#Case%20notes)."
+                + "#Directions)."
         );
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -40,15 +40,6 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");
 
-        BailCase bailCase =
-            callback
-                .getCaseDetails()
-                .getCaseData();
-
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
-
         return postSubmitResponse;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+import static java.util.Objects.requireNonNull;
+
+@Component
+public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public boolean canHandle(Callback<BailCase> callback) {
+        requireNonNull(callback, "callback must not be null");
+        return (callback.getEvent() == Event.SEND_DIRECTION);
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationBody(
+            "### What happens next\n\n"
+                    + "You can see the status of the direction in the [directions tab](/case/IA/Bail/"
+                + callback.getCaseDetails().getId()
+                + "#Case%20notes)."
+        );
+
+        postSubmitResponse.setConfirmationHeader("# You have sent a direction");
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,6 +8,9 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 
 @Component
@@ -17,7 +20,6 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
     public boolean canHandle(Callback<BailCase> callback) {
         requireNonNull(callback, "callback must not be null");
         return (callback.getEvent() == Event.SEND_BAIL_DIRECTION);
-
     }
 
     @Override
@@ -37,6 +39,15 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
         );
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return postSubmitResponse;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmation.java
@@ -8,6 +8,9 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCa
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 @Component
 public class SendDirectionConfirmation implements PostSubmitCallbackHandler<BailCase> {
@@ -35,6 +38,15 @@ public class SendDirectionConfirmation implements PostSubmitCallbackHandler<Bail
         );
 
         postSubmitResponse.setConfirmationHeader("# You have sent a direction");
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return postSubmitResponse;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Direction;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -90,7 +90,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.write(DIRECTIONS, allDirections);
 
 
-
         return new PreSubmitCallbackResponse<>(bailCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -89,7 +89,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.write(DIRECTIONS, allDirections);
 
 
-
         return new PreSubmitCallbackResponse<>(bailCase);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -8,7 +8,6 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
-
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -89,10 +88,12 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
         bailCase.write(DIRECTIONS, allDirections);
 
+
         bailCase.clear(SEND_DIRECTION_DESCRIPTION);
         bailCase.clear(SEND_DIRECTION_LIST);
         bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -6,7 +6,7 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import java.util.List;
@@ -14,13 +14,11 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.CaseNote;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Direction;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.Appender;
@@ -50,7 +48,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_DIRECTION);
+        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_BAIL_DIRECTION);
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(
@@ -97,9 +95,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
         bailCase.write(DIRECTION, allDirections);
 
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -5,13 +5,8 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-<<<<<<< HEAD
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
-=======
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
->>>>>>> 1c61fd5 (Backend for directions screen)
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import java.util.List;
@@ -101,5 +96,4 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -91,6 +91,9 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
         bailCase.write(DIRECTIONS, allDirections);
 
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -88,6 +88,9 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
         bailCase.write(DIRECTIONS, allDirections);
 
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.CaseNote;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.Appender;
+
+
+@Component
+public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    private final Appender<Direction> directionAppender;
+    private final DateProvider dateProvider;
+    private final UserDetails userDetails;
+
+    public SendDirectionHandler(
+        Appender<Direction> directionAppender,
+        DateProvider dateProvider,
+        UserDetails userDetails
+    ) {
+        this.directionAppender = directionAppender;
+        this.dateProvider = dateProvider;
+        this.userDetails = userDetails;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_DIRECTION);
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        String directionDescription = bailCase
+                .read(SEND_DIRECTION_DESCRIPTION, String.class)
+                .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
+
+        String directionList = bailCase
+                .read(SEND_DIRECTION_LIST, String.class)
+                .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
+
+        String dateOfCompliance = bailCase
+                .read(DATE_OF_COMPLIANCE, String.class)
+                .orElseThrow(() -> new IllegalStateException("dateOfCompliance is not present"));
+
+
+        Optional<List<IdValue<Direction>>> maybeExistingDirections =
+            bailCase.read(DIRECTION);
+
+
+
+        final Direction newDirection = new Direction(
+            directionDescription,
+            directionList,
+            dateOfCompliance,
+            buildFullName(),
+            dateProvider.now().toString()
+        );
+
+
+        List<IdValue<Direction>> allDirections =
+            directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
+
+        bailCase.write(DIRECTION, allDirections);
+
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
+
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+    private String buildFullName() {
+        return userDetails.getForename()
+            + " "
+            + userDetails.getSurname();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -36,7 +36,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
     ) {
         this.directionAppender = directionAppender;
         this.dateProvider = dateProvider;
-
     }
 
     public boolean canHandle(
@@ -68,7 +67,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
                 .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
 
         String sendDirectionList = bailCase
-
                 .read(SEND_DIRECTION_LIST, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
 
@@ -78,6 +76,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
 
         Optional<List<IdValue<Direction>>> maybeExistingDirections =
+
             bailCase.read(DIRECTIONS);
 
 
@@ -85,14 +84,12 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             sendDirectionDescription,
             sendDirectionList,
             dateOfCompliance,
-
             dateProvider.now().toString()
         );
 
 
         List<IdValue<Direction>> allDirections =
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
-
         bailCase.write(DIRECTIONS, allDirections);
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -29,7 +29,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
     private final Appender<Direction> directionAppender;
     private final DateProvider dateProvider;
 
-
     public SendDirectionHandler(
         Appender<Direction> directionAppender,
         DateProvider dateProvider
@@ -75,7 +74,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
 
         Optional<List<IdValue<Direction>>> maybeExistingDirections =
-
             bailCase.read(DIRECTIONS);
 
 
@@ -90,7 +88,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         List<IdValue<Direction>> allDirections =
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
         bailCase.write(DIRECTIONS, allDirections);
-
 
 
         return new PreSubmitCallbackResponse<>(bailCase);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -5,8 +5,13 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+<<<<<<< HEAD
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
+=======
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
+>>>>>>> 1c61fd5 (Backend for directions screen)
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import java.util.List;
@@ -88,6 +93,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         List<IdValue<Direction>> allDirections =
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
         bailCase.write(DIRECTIONS, allDirections);
+
 
         bailCase.clear(SEND_DIRECTION_DESCRIPTION);
         bailCase.clear(SEND_DIRECTION_LIST);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -66,11 +66,11 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
                 .getCaseDetails()
                 .getCaseData();
 
-        String directionDescription = bailCase
+        String sendDirectionDescription = bailCase
                 .read(SEND_DIRECTION_DESCRIPTION, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
 
-        String directionList = bailCase
+        String sendDirectionList = bailCase
                 .read(SEND_DIRECTION_LIST, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
 
@@ -85,10 +85,9 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
 
         final Direction newDirection = new Direction(
-            directionDescription,
-            directionList,
+            sendDirectionDescription,
+            sendDirectionList,
             dateOfCompliance,
-            buildFullName(),
             dateProvider.now().toString()
         );
 
@@ -103,11 +102,5 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
-    }
-
-    private String buildFullName() {
-        return userDetails.getForename()
-            + " "
-            + userDetails.getSurname();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -89,6 +89,9 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
         bailCase.write(DIRECTIONS, allDirections);
 
+        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
+        bailCase.clear(SEND_DIRECTION_LIST);
+        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -89,11 +89,8 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.write(DIRECTIONS, allDirections);
 
 
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }
-    
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -46,7 +46,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_BAIL_DIRECTION);
-
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(
@@ -93,9 +92,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.write(DIRECTIONS, allDirections);
 
 
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -29,12 +29,14 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
     private final Appender<Direction> directionAppender;
     private final DateProvider dateProvider;
 
+
     public SendDirectionHandler(
         Appender<Direction> directionAppender,
         DateProvider dateProvider
     ) {
         this.directionAppender = directionAppender;
         this.dateProvider = dateProvider;
+
     }
 
     public boolean canHandle(
@@ -45,6 +47,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(SEND_BAIL_DIRECTION);
+
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(
@@ -65,6 +68,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
                 .orElseThrow(() -> new IllegalStateException("sendDirectionDescription is not present"));
 
         String sendDirectionList = bailCase
+
                 .read(SEND_DIRECTION_LIST, String.class)
                 .orElseThrow(() -> new IllegalStateException("sendDirectionList is not present"));
 
@@ -77,11 +81,11 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             bailCase.read(DIRECTIONS);
 
 
-
         final Direction newDirection = new Direction(
             sendDirectionDescription,
             sendDirectionList,
             dateOfCompliance,
+
             dateProvider.now().toString()
         );
 
@@ -91,10 +95,12 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
         bailCase.write(DIRECTIONS, allDirections);
 
+
         bailCase.clear(SEND_DIRECTION_DESCRIPTION);
         bailCase.clear(SEND_DIRECTION_LIST);
         bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -90,9 +90,6 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.write(DIRECTIONS, allDirections);
 
 
-        bailCase.clear(SEND_DIRECTION_DESCRIPTION);
-        bailCase.clear(SEND_DIRECTION_LIST);
-        bailCase.clear(DATE_OF_COMPLIANCE);
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
@@ -29,16 +29,13 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
     private final Appender<Direction> directionAppender;
     private final DateProvider dateProvider;
-    private final UserDetails userDetails;
 
     public SendDirectionHandler(
         Appender<Direction> directionAppender,
-        DateProvider dateProvider,
-        UserDetails userDetails
+        DateProvider dateProvider
     ) {
         this.directionAppender = directionAppender;
         this.dateProvider = dateProvider;
-        this.userDetails = userDetails;
     }
 
     public boolean canHandle(
@@ -78,7 +75,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
 
         Optional<List<IdValue<Direction>>> maybeExistingDirections =
-            bailCase.read(DIRECTION);
+            bailCase.read(DIRECTIONS);
 
 
 
@@ -93,7 +90,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         List<IdValue<Direction>> allDirections =
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
 
-        bailCase.write(DIRECTION, allDirections);
+        bailCase.write(DIRECTIONS, allDirections);
 
 
         return new PreSubmitCallbackResponse<>(bailCase);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -95,5 +95,5 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
 
         return new PreSubmitCallbackResponse<>(bailCase);
     }
-
+    
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DirectionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DirectionTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DirectionTest {
+
+    private final String sendDirectionDescription = "some-description";
+    private final String dateOfCompliance = "2022-05-26";
+    private final String dateSent = "2022-05-25";
+    private final String sendDirectionList = "Applicant";
+
+    private Direction direction;
+
+    @BeforeEach
+    public void setUp() {
+        direction = new Direction(
+            sendDirectionDescription,
+            sendDirectionList,
+            dateOfCompliance,
+            dateSent
+        );
+    }
+
+    @Test
+    void should_hold_onto_values() {
+
+        assertThat(direction.getSendDirectionDescription()).isEqualTo(sendDirectionDescription);
+        assertThat(direction.getDateOfCompliance()).isEqualTo(dateOfCompliance);
+        assertThat(direction.getSendDirectionList()).isEqualTo(sendDirectionList);
+        assertThat(direction.getDateSent()).isEqualTo(dateSent);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> new Direction(null, "", "", ""))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new Direction("", null, "", ""))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new Direction("", "", null, ""))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new Direction("", "", "", null))
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -18,11 +18,12 @@ public class EventTest {
         assertEquals("moveApplicationToDecided", Event.MOVE_APPLICATION_TO_DECIDED.toString());
         assertEquals("uploadDocuments", Event.UPLOAD_DOCUMENTS.toString());
         assertEquals("editDocuments", Event.EDIT_DOCUMENTS.toString());
+        assertEquals("sendBailDirection", Event.SEND_BAIL_DIRECTION.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(11, Event.values().length);
+        assertEquals(12, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -6,12 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +38,6 @@ public class SendDirectionConfirmationTest {
         when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getId()).thenReturn(111L);
-        when(caseDetails.getCaseData()).thenReturn(bailCase);
 
         PostSubmitCallbackResponse callbackResponse =
             sendDirectionConfirmation.handle(callback);
@@ -60,20 +54,6 @@ public class SendDirectionConfirmationTest {
             callbackResponse.getConfirmationBody().get())
             .contains("You can see the status of the direction in the [directions tab]");
 
-    }
-
-    @Test
-    void should_clear_fields() {
-        when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getId()).thenReturn(111L);
-        when(caseDetails.getCaseData()).thenReturn(bailCase);
-
-        sendDirectionConfirmation.handle(callback);
-
-        verify(bailCase, times(1)).clear(SEND_DIRECTION_DESCRIPTION);
-        verify(bailCase, times(1)).clear(SEND_DIRECTION_LIST);
-        verify(bailCase, times(1)).clear(DATE_OF_COMPLIANCE);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -71,7 +71,9 @@ public class SendDirectionConfirmationTest {
         AssertionsForClassTypes.assertThat(response.getConfirmationBody().get()).contains("### What happens next");
 
         Assertions.assertNotNull(response.getConfirmationHeader(), "Confirmation Header is null");
-        AssertionsForClassTypes.assertThat(response.getConfirmationHeader().get()).isEqualTo("# You have sent a direction");
+        AssertionsForClassTypes.assertThat(
+            response.getConfirmationHeader().get()).isEqualTo("# You have sent a direction");
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -7,7 +7,6 @@ import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
-
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -54,6 +56,22 @@ public class SendDirectionConfirmationTest {
             callbackResponse.getConfirmationBody().get())
             .contains("You can see the status of the direction in the [directions tab]");
 
+    }
+
+    @Test
+    void should_set_header_body() {
+        when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
+
+        long caseId = 1234L;
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getId()).thenReturn(caseId);
+        PostSubmitCallbackResponse response = sendDirectionConfirmation.handle(callback);
+
+        Assertions.assertNotNull(response.getConfirmationBody(), "Confirmation Body is null");
+        AssertionsForClassTypes.assertThat(response.getConfirmationBody().get()).contains("### What happens next");
+
+        Assertions.assertNotNull(response.getConfirmationHeader(), "Confirmation Header is null");
+        AssertionsForClassTypes.assertThat(response.getConfirmationHeader().get()).isEqualTo("# You have sent a direction");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -58,7 +58,6 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
-
     void should_set_header_body() {
         when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
 
@@ -77,7 +76,6 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
-
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> sendDirectionConfirmation.handle(callback))

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -1,0 +1,120 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class SendDirectionConfirmationTest {
+
+    @Mock
+    private Callback<BailCase> callback;
+
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+
+    @Mock
+    private BailCase bailCase;
+
+    private SendDirectionConfirmation sendDirectionConfirmation = new SendDirectionConfirmation();
+
+    @Test
+    void should_return_confirmation() {
+        when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(111L);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        PostSubmitCallbackResponse callbackResponse =
+            sendDirectionConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("# You have sent a direction");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("You can see the status of the direction in the [directions tab]");
+
+    }
+
+    @Test
+    void should_clear_fields() {
+        when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(111L);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        sendDirectionConfirmation.handle(callback);
+
+        verify(bailCase, times(1)).clear(SEND_DIRECTION_DESCRIPTION);
+        verify(bailCase, times(1)).clear(SEND_DIRECTION_LIST);
+        verify(bailCase, times(1)).clear(DATE_OF_COMPLIANCE);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> sendDirectionConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = sendDirectionConfirmation.canHandle(callback);
+
+            if (event == Event.SEND_BAIL_DIRECTION) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> sendDirectionConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> sendDirectionConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -58,6 +58,7 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
+<<<<<<< HEAD
     void should_set_header_body() {
         when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -58,7 +58,6 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
-<<<<<<< HEAD
     void should_set_header_body() {
         when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/SendDirectionConfirmationTest.java
@@ -58,6 +58,7 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
+
     void should_set_header_body() {
         when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
 
@@ -76,6 +77,7 @@ public class SendDirectionConfirmationTest {
     }
 
     @Test
+
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> sendDirectionConfirmation.handle(callback))

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -111,10 +111,7 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
-<<<<<<< HEAD
 
-=======
->>>>>>> 5230312 (RIA-5556 Revert clearing of fields back into the pre-submit handler)
     void should_clear_fields_for_direction_being_sent() {
 
         PreSubmitCallbackResponse<BailCase> callbackResponse =
@@ -126,10 +123,7 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
-<<<<<<< HEAD
 
-=======
->>>>>>> 5230312 (RIA-5556 Revert clearing of fields back into the pre-submit handler)
     void should_throw_when_direction_description_is_not_present() {
 
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -1,0 +1,184 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DATE_OF_COMPLIANCE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_DESCRIPTION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.Appender;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class SendDirectionHandlerTest {
+
+    @Mock
+    private Appender<Direction> directionAppender;
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+    @Mock private DateProvider dateProvider;
+    @Mock private Direction existingDirection;
+    @Mock private List allAppendedDirections;
+
+    @Captor private ArgumentCaptor<List<IdValue<Direction>>> existingDirectionsCaptor;
+    @Captor private ArgumentCaptor<Direction> newDirectionCaptor;
+
+    private final List<Direction> existingDirections = singletonList(existingDirection);
+    private final LocalDate now = LocalDate.now();
+    private final String newDirectionDateOfCompliance = "2022-05-26";
+    private final String newDirectionDescription = "some-description";
+    private final String newDirectionRecipient = "some-recipient";
+    private SendDirectionHandler sendDirectionHandler;
+
+    @BeforeEach
+    public void setUp() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SEND_BAIL_DIRECTION);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        when(dateProvider.now()).thenReturn(now);
+
+        when(bailCase.read(DIRECTIONS)).thenReturn(Optional.of(existingDirections));
+        when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.of(newDirectionDescription));
+        when(bailCase.read(SEND_DIRECTION_LIST, String.class)).thenReturn(Optional.of(newDirectionRecipient));
+        when(bailCase.read(DATE_OF_COMPLIANCE, String.class)).thenReturn(Optional.of(newDirectionDateOfCompliance));
+
+
+        when(directionAppender.append(any(Direction.class), anyList()))
+            .thenReturn(allAppendedDirections);
+
+        sendDirectionHandler =
+            new SendDirectionHandler(
+                directionAppender,
+                dateProvider
+            );
+    }
+
+    @Test
+    void should_append_new_direction_to_existing_directions() {
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+
+        verify(directionAppender, times(1)).append(
+            newDirectionCaptor.capture(),
+            existingDirectionsCaptor.capture());
+
+        Direction capturedDirection = newDirectionCaptor.getValue();
+
+        assertThat(capturedDirection.getSendDirectionDescription()).isEqualTo(newDirectionDescription);
+        assertThat(capturedDirection.getSendDirectionList()).isEqualTo(newDirectionRecipient);
+        assertThat(capturedDirection.getDateOfCompliance()).isEqualTo(newDirectionDateOfCompliance);
+        assertThat(capturedDirection.getDateSent()).isEqualTo(now.toString());
+
+        assertThat(existingDirectionsCaptor.getValue()).isEqualTo(existingDirections);
+
+        verify(bailCase, times(1)).write(DIRECTIONS, allAppendedDirections);
+
+        assertThat(callbackResponse.getData()).isEqualTo(callbackResponse.getData());
+    }
+
+    @Test
+    void should_throw_when_direction_description_is_not_present() {
+
+        when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("sendDirectionDescription is not present")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_throw_when_direction_recipient_is_not_present() {
+
+        when(bailCase.read(SEND_DIRECTION_LIST, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("sendDirectionList is not present")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPLICATION);
+        assertThatThrownBy(() -> sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = sendDirectionHandler.canHandle(callbackStage, callback);
+
+                assertThat(canHandle).isEqualTo(callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                                                && event.equals(Event.SEND_BAIL_DIRECTION));
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> sendDirectionHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> sendDirectionHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> sendDirectionHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -111,7 +111,6 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
-
     void should_clear_fields_for_direction_being_sent() {
 
         PreSubmitCallbackResponse<BailCase> callbackResponse =
@@ -123,7 +122,6 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
-
     void should_throw_when_direction_description_is_not_present() {
 
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -111,6 +111,17 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
+    void should_clear_fields_for_direction_being_sent() {
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            sendDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(bailCase, times(1)).clear(SEND_DIRECTION_DESCRIPTION);
+        verify(bailCase, times(1)).clear(SEND_DIRECTION_LIST);
+        verify(bailCase, times(1)).clear(DATE_OF_COMPLIANCE);
+    }
+
+    @Test
     void should_throw_when_direction_description_is_not_present() {
 
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -111,6 +111,7 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
+
     void should_clear_fields_for_direction_being_sent() {
 
         PreSubmitCallbackResponse<BailCase> callbackResponse =
@@ -122,6 +123,7 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
+
     void should_throw_when_direction_description_is_not_present() {
 
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -111,7 +111,10 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
+<<<<<<< HEAD
 
+=======
+>>>>>>> 5230312 (RIA-5556 Revert clearing of fields back into the pre-submit handler)
     void should_clear_fields_for_direction_being_sent() {
 
         PreSubmitCallbackResponse<BailCase> callbackResponse =
@@ -123,7 +126,10 @@ public class SendDirectionHandlerTest {
     }
 
     @Test
+<<<<<<< HEAD
 
+=======
+>>>>>>> 5230312 (RIA-5556 Revert clearing of fields back into the pre-submit handler)
     void should_throw_when_direction_description_is_not_present() {
 
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.empty());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5556


### Change description ###
As an admin/judge 

I want to send the direction to parties,

So that they are aware of what to do next.

Acceptance Criteria

Send direction event can be triggered at application submitted, listing, bail summary, hearing state

Send direction should be shown in the event list as attached (send_direction_event.png)

Send direction event can be triggered in 2 ways.

 Select Send direction event from the dropdown
Click on Send a new direction link from the directions tab.
Then the following screens should appear in the order.

1) Direction details

     1.1 Free text box to explain the direction you are issuing

     1.2 Dropdown to select who are you giving the direction to ?

         Dropdown should have the values

                       Select a value
                       Legal representative
                       Home Office
                       Applicant
    1.3 By what date must they comply (Day Month Year) - Should be the future date

2) Check your answer

3) Success page

4) Updated overview page with the progress bar image as same state as before.

Direction details should be available in direction tab (will be covered in https://tools.hmcts.net/jira/browse/RIA-5557)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
