### PR TITLE
RIA-5597 Add SEND_BAIL_DIRECTION to events to handle for notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Direction.java
@@ -13,6 +13,8 @@ public class Direction {
     private String sendDirectionList;
     private String dateOfCompliance;
     private String dateSent;
+    private String dateTimeDirectionCreated;
+    private String dateTimeDirectionModified;
 
     private Direction() {
     }
@@ -21,12 +23,16 @@ public class Direction {
         String sendDirectionDescription,
         String sendDirectionList,
         String dateOfCompliance,
-        String dateSent
+        String dateSent,
+        String dateTimeDirectionCreated,
+        String dateTimeDirectionModified
     ) {
         this.sendDirectionDescription = requireNonNull(sendDirectionDescription);
         this.sendDirectionList = requireNonNull(sendDirectionList);
         this.dateOfCompliance = requireNonNull(dateOfCompliance);
         this.dateSent = requireNonNull(dateSent);
+        this.dateTimeDirectionCreated = requireNonNull(dateTimeDirectionCreated);
+        this.dateTimeDirectionModified = dateTimeDirectionModified;
     }
 
 
@@ -46,5 +52,11 @@ public class Direction {
         return requireNonNull(dateSent);
     }
 
+    public String getDateTimeDirectionCreated() {
+        return dateTimeDirectionCreated;
+    }
 
+    public String getDateTimeDirectionModified() {
+        return dateTimeDirectionModified;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -8,7 +8,6 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.SEND_BAIL_DIRECTION;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -83,9 +82,10 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
             sendDirectionDescription,
             sendDirectionList,
             dateOfCompliance,
-            now.toString()
+            now.toString(),
+            dateProvider.nowWithTime().toString(),
+            null
         );
-
 
         List<IdValue<Direction>> allDirections =
             directionAppender.append(newDirection, maybeExistingDirections.orElse(emptyList()));
@@ -104,7 +104,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.clear(SEND_DIRECTION_LIST);
         bailCase.clear(DATE_OF_COMPLIANCE);
 
-        return response;
+        return new PreSubmitCallbackResponse<>(bailCase);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandler.java
@@ -104,7 +104,7 @@ public class SendDirectionHandler implements PreSubmitCallbackHandler<BailCase> 
         bailCase.clear(SEND_DIRECTION_LIST);
         bailCase.clear(DATE_OF_COMPLIANCE);
 
-        return new PreSubmitCallbackResponse<>(bailCase);
+        return response;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -47,7 +47,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<BailCas
             Event.UPLOAD_BAIL_SUMMARY,
             Event.UPLOAD_SIGNED_DECISION_NOTICE,
             Event.END_APPLICATION,
-            Event.UPLOAD_DOCUMENTS
+            Event.UPLOAD_DOCUMENTS,
+            Event.SEND_BAIL_DIRECTION
         );
         return eventsToHandle;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DirectionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DirectionTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,8 @@ class DirectionTest {
     private final String dateOfCompliance = "2022-05-26";
     private final String dateSent = "2022-05-25";
     private final String sendDirectionList = "Applicant";
+    private final String dateTimeDirectionCreated = "2022-05-25T10:00:00Z";
+    private final String dateTimeDirectionModified = "2022-05-25T15:00:00Z";
 
     private Direction direction;
 
@@ -21,7 +24,9 @@ class DirectionTest {
             sendDirectionDescription,
             sendDirectionList,
             dateOfCompliance,
-            dateSent
+            dateSent,
+            dateTimeDirectionCreated,
+            dateTimeDirectionModified
         );
     }
 
@@ -32,22 +37,29 @@ class DirectionTest {
         assertThat(direction.getDateOfCompliance()).isEqualTo(dateOfCompliance);
         assertThat(direction.getSendDirectionList()).isEqualTo(sendDirectionList);
         assertThat(direction.getDateSent()).isEqualTo(dateSent);
+        assertThat(direction.getDateTimeDirectionCreated()).isEqualTo(dateTimeDirectionCreated);
+        assertThat(direction.getDateTimeDirectionModified()).isEqualTo(dateTimeDirectionModified);
     }
 
     @Test
     void should_not_allow_null_arguments() {
 
-        assertThatThrownBy(() -> new Direction(null, "", "", ""))
+        assertThatThrownBy(() -> new Direction(null, "", "", "", "", ""))
             .isExactlyInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> new Direction("", null, "", ""))
+        assertThatThrownBy(() -> new Direction("", null, "", "", "", ""))
             .isExactlyInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> new Direction("", "", null, ""))
+        assertThatThrownBy(() -> new Direction("", "", null, "", "", ""))
             .isExactlyInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> new Direction("", "", "", null))
+        assertThatThrownBy(() -> new Direction("", "", "", null, "", ""))
             .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new Direction("", "", "", "", null, ""))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertDoesNotThrow(() -> new Direction("", "", "", "", "", null));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendDirectionHandlerTest.java
@@ -16,6 +16,7 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SEND_DIRECTION_LIST;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -73,6 +74,7 @@ public class SendDirectionHandlerTest {
         when(caseDetails.getCaseData()).thenReturn(bailCase);
 
         when(dateProvider.now()).thenReturn(now);
+        when(dateProvider.nowWithTime()).thenReturn(LocalDateTime.now());
 
         when(bailCase.read(DIRECTIONS)).thenReturn(Optional.of(existingDirections));
         when(bailCase.read(SEND_DIRECTION_DESCRIPTION, String.class)).thenReturn(Optional.of(newDirectionDescription));

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -106,7 +106,8 @@ class SendNotificationHandlerTest {
                         Event.UPLOAD_BAIL_SUMMARY,
                         Event.UPLOAD_SIGNED_DECISION_NOTICE,
                         Event.END_APPLICATION,
-                        Event.UPLOAD_DOCUMENTS
+                        Event.UPLOAD_DOCUMENTS,
+                        Event.SEND_BAIL_DIRECTION
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5597](https://tools.hmcts.net/jira/browse/RIA-5597)


### Change description ###
- Added SEND_BAIL_DIRECTION to the list of events to send notifications for


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (if merged before notifications)
[x] No (if merged after notifications)
```
