### PR TITLE
RIA-5559 Add "editBailDocuments" to SendNotificationHandler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -48,7 +48,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<BailCas
             Event.UPLOAD_SIGNED_DECISION_NOTICE,
             Event.END_APPLICATION,
             Event.UPLOAD_DOCUMENTS,
-            Event.SEND_BAIL_DIRECTION
+            Event.SEND_BAIL_DIRECTION,
+            Event.EDIT_BAIL_DOCUMENTS
         );
         return eventsToHandle;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -107,7 +107,8 @@ class SendNotificationHandlerTest {
                         Event.UPLOAD_SIGNED_DECISION_NOTICE,
                         Event.END_APPLICATION,
                         Event.UPLOAD_DOCUMENTS,
-                        Event.SEND_BAIL_DIRECTION
+                        Event.SEND_BAIL_DIRECTION,
+                        Event.EDIT_BAIL_DOCUMENTS
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5559](https://tools.hmcts.net/jira/browse/RIA-5559)


### Change description ###
- Added "editBailDocuments" to events to be handled for notifications


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
