### PR TITLE
RIA-5763 Explicitly set flags also for sad path

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
@@ -67,6 +67,9 @@ public class CaseInferenceByBailNumberHandler implements PreSubmitCallbackHandle
                                   + "1111222233334444) or 8 characters long and following the ARIA format (e.g. "
                                   + "Hw/12345)");
             }
+        } else {
+            bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.NO);
+            bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.NO);
         }
 
         return response;

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
@@ -128,6 +128,19 @@ public class CaseInferenceByBailNumberHandlerTest {
     }
 
     @Test
+    void should_set_case_not_done_via_ccd_or_aria_if_applicant_has_no_previous_case() {
+
+        when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        caseInferenceByBailNumberHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.NO);
+        verify(bailCase,  times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.NO);
+    }
+
+    @Test
     void it_can_handle_callback_for_all_events() {
 
         for (Event event : Event.values()) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5763](https://tools.hmcts.net/jira/browse/RIA-5763)


### Change description ###
- Added explicit setting of flags even for sad path, in order to prevent screens showing up when flags (used as show conditions) are set and then not overwritten when going back and forth through the journey


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
