### PR TITLE
RIA-5763 Add midEvent handler + expand midEvent endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -19,8 +19,8 @@ public enum BailCaseFieldDefinition {
         "previousApplicationDoneViaAria", new TypeReference<YesOrNo>() {}),
     PREVIOUS_APPLICATION_DONE_VIA_CCD(
         "previousApplicationDoneViaCcd", new TypeReference<YesOrNo>() {}),
-    PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE(
-        "previousApplicationScanCaseReference", new TypeReference<String>() {}),
+    REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC(
+        "redirectToPreviousApplicationOrNoc", new TypeReference<String>() {}),
     APPLICATION_SENT_BY(
         "sentByChecklist", new TypeReference<String>() {}),
     IS_ADMIN(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/callback/Callback.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/callback/Callback.java
@@ -20,6 +20,8 @@ public class Callback<T extends CaseData> {
     private CaseDetails<T> caseDetails;
     private Optional<CaseDetails<T>> caseDetailsBefore = Optional.empty();
 
+    private String pageId = "";
+
     private Callback() {
     }
 
@@ -50,5 +52,13 @@ public class Callback<T extends CaseData> {
 
     public Optional<CaseDetails<T>> getCaseDetailsBefore() {
         return caseDetailsBefore;
+    }
+
+    public String getPageId() {
+        return pageId;
+    }
+
+    public void setPageId(String pageId) {
+        this.pageId = pageId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
@@ -5,7 +5,6 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_DONE_VIA_ARIA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_DONE_VIA_CCD;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.HAS_PREVIOUS_BAIL_APPLICATION;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
@@ -34,7 +34,8 @@ public class CaseInferenceByBailNumberHandler implements PreSubmitCallbackHandle
 
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
                && (callback.getEvent() == Event.START_APPLICATION
-               || callback.getEvent() == Event.EDIT_BAIL_APPLICATION);
+               || callback.getEvent() == Event.EDIT_BAIL_APPLICATION)
+               && callback.getPageId().equals(HAS_PREVIOUS_BAIL_APPLICATION.value());
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(
@@ -54,12 +55,10 @@ public class CaseInferenceByBailNumberHandler implements PreSubmitCallbackHandle
 
         String bailReferenceNumber = bailCase.read(PREVIOUS_BAIL_APPLICATION_NUMBER, String.class).orElse("");
         String hasPreviousBailApplication = bailCase.read(HAS_PREVIOUS_BAIL_APPLICATION, String.class).orElse("");
-
         if (hasPreviousBailApplication.equals("yes")) {
             if (bailReferenceNumber.matches("[0-9]{16}")) {
                 bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.YES);
                 bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.NO);
-                bailCase.write(PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE, bailReferenceNumber);
             } else if (bailReferenceNumber.matches("[a-zA-Z]{2}\\/[0-9]{5}")) {
                 bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.NO);
                 bailCase.write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.YES);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppender.java
@@ -49,7 +49,7 @@ public class ErrorForStartApplicationAppender implements PreSubmitCallbackHandle
 
         response.addError("A case record already exists for this applicant.\n"
                           + "If you did not make a previous application on the applicant’s behalf you will need to "
-                          + "acquire the case record to continue.  You can do so by using Notice of Change\n"
+                          + "acquire the case record to continue. You can do so by using Notice of Change.\n"
                           + "If you did you need to find the applicant in your case list and make a new application "
                           + "from within the existing record.");
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppender.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class ErrorForStartApplicationAppender implements PreSubmitCallbackHandler<BailCase> {
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.EARLIEST;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.MID_EVENT
+               && callback.getEvent() == Event.START_APPLICATION
+               && callback.getPageId().equals(REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC.value());
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<BailCase> response = new PreSubmitCallbackResponse<>(bailCase);
+
+        response.addError("A case record already exists for this applicant.\n"
+                          + "If you did not make a previous application on the applicant’s behalf you will need to "
+                          + "acquire the case record to continue.  You can do so by using Notice of Change\n"
+                          + "If you did you need to find the applicant in your case list and make a new application "
+                          + "from within the existing record.");
+
+        return response;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/PreSubmitCallbackDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/PreSubmitCallbackDispatcher.java
@@ -142,6 +142,8 @@ public class PreSubmitCallbackDispatcher<T extends CaseData> {
                 callback.getEvent()
             );
 
+            callbackForHandler.setPageId(callback.getPageId());
+
             if (callbackStateHandler.canHandle(callbackStage, callbackForHandler)) {
                 PreSubmitCallbackResponse<T> callbackResponseFromHandler =
                     callbackStateHandler.handle(callbackStage, callbackForHandler, callbackResponse);
@@ -178,6 +180,8 @@ public class PreSubmitCallbackDispatcher<T extends CaseData> {
                     callback.getCaseDetailsBefore(),
                     callback.getEvent()
                 );
+
+                callbackForHandler.setPageId(callback.getPageId());
 
                 if (callbackHandler.canHandle(callbackStage, callbackForHandler)) {
                     PreSubmitCallbackResponse<T> callbackResponseFromHandler =

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/controllers/PreSubmitCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/controllers/PreSubmitCallbackController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
@@ -129,8 +130,12 @@ public class PreSubmitCallbackController {
 
     @PostMapping(path = "/ccdMidEvent")
     public ResponseEntity<PreSubmitCallbackResponse<BailCase>> ccdMidEvent(
-        @Parameter(name = "Bail case data", required = true) @NotNull @RequestBody Callback<BailCase> callback
+        @Parameter(name = "Bail case data", required = true) @NotNull @RequestBody Callback<BailCase> callback,
+        @RequestParam(name = "pageId", required = false) String pageId
     ) {
+        if (pageId != null) {
+            callback.setPageId(pageId);
+        }
         return performStageRequest(PreSubmitCallbackStage.MID_EVENT, callback);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
@@ -13,11 +13,9 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_BAIL_APPLICATION_NUMBER;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_DONE_VIA_ARIA;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_DONE_VIA_CCD;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE;
 
 import java.util.Optional;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -43,11 +41,6 @@ public class CaseInferenceByBailNumberHandlerTest {
 
     private CaseInferenceByBailNumberHandler caseInferenceByBailNumberHandler = new CaseInferenceByBailNumberHandler();
 
-    @BeforeEach
-    void setup() {
-
-    }
-
     @Test
     void should_infer_bail_case_from_application_number() {
         String bailCaseReferenceNumber = "1111222233334444";
@@ -55,6 +48,7 @@ public class CaseInferenceByBailNumberHandlerTest {
         when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(HAS_PREVIOUS_BAIL_APPLICATION.value());
         when(bailCase.read(HAS_PREVIOUS_BAIL_APPLICATION, String.class))
             .thenReturn(Optional.of("yes"));
         when(bailCase.read(PREVIOUS_BAIL_APPLICATION_NUMBER, String.class))
@@ -63,7 +57,6 @@ public class CaseInferenceByBailNumberHandlerTest {
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             caseInferenceByBailNumberHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
 
-        verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE, bailCaseReferenceNumber);
         verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.YES);
         verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.NO);
 
@@ -77,6 +70,7 @@ public class CaseInferenceByBailNumberHandlerTest {
         when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(HAS_PREVIOUS_BAIL_APPLICATION.value());
         when(bailCase.read(HAS_PREVIOUS_BAIL_APPLICATION, String.class))
             .thenReturn(Optional.of("yes"));
         when(bailCase.read(PREVIOUS_BAIL_APPLICATION_NUMBER, String.class))
@@ -85,7 +79,6 @@ public class CaseInferenceByBailNumberHandlerTest {
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             caseInferenceByBailNumberHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
 
-        verify(bailCase, never()).write(PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE, ariaCaseReferenceNumber);
         verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.NO);
         verify(bailCase, times(1)).write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.YES);
 
@@ -99,6 +92,7 @@ public class CaseInferenceByBailNumberHandlerTest {
         when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(HAS_PREVIOUS_BAIL_APPLICATION.value());
         when(bailCase.read(HAS_PREVIOUS_BAIL_APPLICATION, String.class))
             .thenReturn(Optional.of("yes"));
         when(bailCase.read(PREVIOUS_BAIL_APPLICATION_NUMBER, String.class))
@@ -107,7 +101,6 @@ public class CaseInferenceByBailNumberHandlerTest {
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             caseInferenceByBailNumberHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
 
-        verify(bailCase, never()).write(PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE, wrongCaseReferenceNumber);
         verify(bailCase, never()).write(PREVIOUS_APPLICATION_DONE_VIA_CCD, YesOrNo.NO);
         verify(bailCase,  never()).write(PREVIOUS_APPLICATION_DONE_VIA_ARIA, YesOrNo.YES);
 
@@ -133,6 +126,7 @@ public class CaseInferenceByBailNumberHandlerTest {
         when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(HAS_PREVIOUS_BAIL_APPLICATION.value());
 
         caseInferenceByBailNumberHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
 
@@ -146,6 +140,7 @@ public class CaseInferenceByBailNumberHandlerTest {
         for (Event event : Event.values()) {
 
             when(callback.getEvent()).thenReturn(event);
+            when(callback.getPageId()).thenReturn(HAS_PREVIOUS_BAIL_APPLICATION.value());
 
             for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
 
@@ -153,7 +148,8 @@ public class CaseInferenceByBailNumberHandlerTest {
 
                 if (callbackStage == PreSubmitCallbackStage.MID_EVENT
                     && (callback.getEvent() == Event.START_APPLICATION
-                    || callback.getEvent() == Event.EDIT_BAIL_APPLICATION)) {
+                        || callback.getEvent() == Event.EDIT_BAIL_APPLICATION)
+                    && callback.getPageId().equals(HAS_PREVIOUS_BAIL_APPLICATION.value())) {
 
                     assertTrue(canHandle);
                 } else {

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppenderTest.java
@@ -46,7 +46,7 @@ public class ErrorForStartApplicationAppenderTest {
 
         String expectedError = "A case record already exists for this applicant.\n"
                                + "If you did not make a previous application on the applicant’s behalf you will need "
-                               + "to acquire the case record to continue.  You can do so by using Notice of Change\n"
+                               + "to acquire the case record to continue. You can do so by using Notice of Change.\n"
                                + "If you did you need to find the applicant in your case list and make a new "
                                + "application from within the existing record.";
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ErrorForStartApplicationAppenderTest.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class ErrorForStartApplicationAppenderTest {
+
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+
+    private ErrorForStartApplicationAppender errorForStartApplicationAppender = new ErrorForStartApplicationAppender();
+
+    @Test
+    void should_add_error_to_bailCase() {
+
+        when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC.value());
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            errorForStartApplicationAppender.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        String expectedError = "A case record already exists for this applicant.\n"
+                               + "If you did not make a previous application on the applicant’s behalf you will need "
+                               + "to acquire the case record to continue.  You can do so by using Notice of Change\n"
+                               + "If you did you need to find the applicant in your case list and make a new "
+                               + "application from within the existing record.";
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors).contains(expectedError);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> errorForStartApplicationAppender.handle(PreSubmitCallbackStage.MID_EVENT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback_for_all_events() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getPageId()).thenReturn(REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC.value());
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = errorForStartApplicationAppender.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.MID_EVENT
+                    && callback.getEvent() == Event.START_APPLICATION
+                    && callback.getPageId().equals(REDIRECT_TO_PREVIOUS_APPLICATION_OR_NOC.value())) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> errorForStartApplicationAppender.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> errorForStartApplicationAppender
+            .canHandle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> errorForStartApplicationAppender.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> errorForStartApplicationAppender.handle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.bailcaseapi.infrastructure.controllers;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -83,6 +85,53 @@ public class PreSubmitCallbackControllerTest {
             PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
             callback
         );
+    }
+
+    @Test
+    void should_dispatch_mid_event_callback_then_return_response() {
+
+        String pageIdParam = "somePageId";
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        doCallRealMethod().when(callback).setPageId(pageIdParam);
+        doCallRealMethod().when(callback).getPageId();
+
+        doReturn(callbackResponse)
+            .when(callbackDispatcher)
+            .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        ResponseEntity<PreSubmitCallbackResponse<BailCase>> actualResponse =
+            preSubmitCallbackController.ccdMidEvent(callback, pageIdParam);
+
+        assertNotNull(actualResponse);
+
+        verify(callbackDispatcher, times(1)).handle(
+            PreSubmitCallbackStage.MID_EVENT,
+            callback
+        );
+        assertEquals(pageIdParam, callback.getPageId());
+    }
+
+    @Test
+    void should_dispatch_mid_event_callback_withou_breaking_if_pageId_null() {
+
+        String pageIdParam = null;
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        doCallRealMethod().when(callback).getPageId();
+
+        doReturn(callbackResponse)
+            .when(callbackDispatcher)
+            .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        ResponseEntity<PreSubmitCallbackResponse<BailCase>> actualResponse =
+            preSubmitCallbackController.ccdMidEvent(callback, pageIdParam);
+
+        assertNotNull(actualResponse);
+
+        verify(callbackDispatcher, times(1)).handle(
+            PreSubmitCallbackStage.MID_EVENT,
+            callback
+        );
+        assertEquals(pageIdParam, callback.getPageId());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5763](https://tools.hmcts.net/jira/browse/RIA-5763)


### Change description ###
- A first midEvent handler was already present (CaseInferenceByBailNumberHandler) which can be activated when:
    - event is START_APPLICATION
    - stage is MID_EVENT
    - pageId is `hasPreviousBailApplication` (the first page in Start Application)
- ErrorForStartApplicationAppender is a second midEvent handler which can be activated when:
    - event is START_APPLICATION
    - stage is MID_EVENT
    - pageId is `redirectToPreviousApplicationOrNoc` (the first page in Start Application)
- PreSubmitCallbackController has been expanded to include an optional `@RequestParam` which is the `pageId`. The `pageId` is added to a new field in `Callback` if it's not null, so that the handlers can use it to understand which midEvent handler is intended to work. This ruse makes it possible to have multiple midEvent calls in the same event without breaking the functionality of existing midEvent calls that don't send the `pageId` as a parameter.
- The field `PREVIOUS_APPLICATION_SCAN_CASE_REFERENCE` is no longer required and doesn't need to be set and pre-populated.

**Acceptance criteria**: when the user indicates the applicant has a previous application and its number is 16 digits (CCD application), a new screen is directs the user to either click on the NOC link (not working now) or click on the link to get to the case list (to look for it themselves)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
