### PR TITLE
Cleared Array when Signed doc is added

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
@@ -7,9 +7,7 @@ import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefin
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
@@ -71,19 +71,13 @@ public class UploadSignedDecisionNoticeHandler implements PreSubmitCallbackHandl
         Document maybeSignedDecisionNotice = bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)
             .orElseThrow(() -> new IllegalStateException("signedDecisionNotice is not present"));
 
-        Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingTribunalDocuments =
-            bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA);
-
-        final List<IdValue<DocumentWithMetadata>> existingTribunalDocuments =
-            maybeExistingTribunalDocuments.orElse(Collections.emptyList());
-
         List<IdValue<DocumentWithMetadata>> allTribunalDocuments = new ArrayList<>();
 
         documentReceiver.tryReceive(
                 new DocumentWithDescription(maybeSignedDecisionNotice, ""), DocumentTag.SIGNED_DECISION_NOTICE)
             .ifPresent(signedDecisionNoticeDocumentWithMetadata ->
                            allTribunalDocuments.addAll(documentsAppender.append(
-                               existingTribunalDocuments, List.of(signedDecisionNoticeDocumentWithMetadata)
+                               allTribunalDocuments, List.of(signedDecisionNoticeDocumentWithMetadata)
             )));
 
         bailCase.write(TRIBUNAL_DOCUMENTS_WITH_METADATA, allTribunalDocuments);

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -92,7 +92,6 @@ public class UploadSignedDecisionNoticeHandlerTest {
     @Test
     void should_add_new_document_to_the_case() {
 
-        //create empty variables
         List<IdValue<DocumentWithMetadata>> allTribunalDocs =
             List.of(
                 new IdValue<>("1", signedDecisionNoticeMetadata1)
@@ -104,31 +103,25 @@ public class UploadSignedDecisionNoticeHandlerTest {
         when(bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA)).thenReturn(
             Optional.empty());
 
-        //add description to doc
         when(documentReceiver.tryReceive(new DocumentWithDescription(signedDecisionNotice1, ""),
                                          DocumentTag.SIGNED_DECISION_NOTICE))
             .thenReturn(Optional.of(signedDecisionNoticeMetadata1));
 
-        //append doc to array
         when(documentsAppender.append(eq(new ArrayList<>()), eq(List.of(signedDecisionNoticeMetadata1))))
             .thenReturn(allTribunalDocs);
 
-        //progress through the screen
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(bailCase, callbackResponse.getData());
 
-        //return data from event
         verify(bailCase, times(1)).read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class);
 
-        //check tag for doc
         verify(documentReceiver, times(1)).tryReceive(
             new DocumentWithDescription(signedDecisionNotice1, ""),
             DocumentTag.SIGNED_DECISION_NOTICE);
-
-
+        
         verify(documentsAppender, times(1))
             .append(existingDecisionNoticeDocumentsCaptor.capture(), eq(List.of(signedDecisionNoticeMetadata1)));
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -62,6 +62,8 @@ public class UploadSignedDecisionNoticeHandlerTest {
     @Mock
     private DocumentWithMetadata signedDecisionNoticeMetadata1;
     @Mock
+    private DocumentWithMetadata unsignedDecisionNoticeMetadata1;
+    @Mock
     private List<IdValue<DocumentWithMetadata>> newSignedDecisionNotice;
     @Mock
     private DateProvider dateProvider;
@@ -87,6 +89,8 @@ public class UploadSignedDecisionNoticeHandlerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
         when(dateProvider.nowWithTime()).thenReturn(nowWithTime);
+        when(signedDecisionNoticeMetadata1.getTag()).thenReturn(DocumentTag.SIGNED_DECISION_NOTICE);
+        when(unsignedDecisionNoticeMetadata1.getTag()).thenReturn(DocumentTag.BAIL_DECISION_UNSIGNED);
     }
 
     @Test
@@ -94,21 +98,24 @@ public class UploadSignedDecisionNoticeHandlerTest {
 
         List<IdValue<DocumentWithMetadata>> allTribunalDocs =
             List.of(
-                new IdValue<>("1", signedDecisionNoticeMetadata1)
+                new IdValue<>("1", signedDecisionNoticeMetadata1),
+                new IdValue<>("2", unsignedDecisionNoticeMetadata1)
             );
 
         when(bailCase.read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class)).thenReturn(
             Optional.of(signedDecisionNotice1));
 
-        when(bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA)).thenReturn(
-            Optional.empty());
+        when(bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA)).thenReturn(Optional.of(List.of(
+            new IdValue<>("1", unsignedDecisionNoticeMetadata1))));
 
         when(documentReceiver.tryReceive(new DocumentWithDescription(signedDecisionNotice1, ""),
-                                         DocumentTag.SIGNED_DECISION_NOTICE))
-            .thenReturn(Optional.of(signedDecisionNoticeMetadata1));
+                                         DocumentTag.SIGNED_DECISION_NOTICE)).thenReturn(Optional.of(
+                                             signedDecisionNoticeMetadata1));
 
-        when(documentsAppender.append(eq(new ArrayList<>()), eq(List.of(signedDecisionNoticeMetadata1))))
-            .thenReturn(allTribunalDocs);
+        when(documentsAppender.append(
+            eq(List.of(new IdValue<>("1", unsignedDecisionNoticeMetadata1))),
+            eq(List.of(signedDecisionNoticeMetadata1))
+        )).thenReturn(allTribunalDocs);
 
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -121,7 +128,7 @@ public class UploadSignedDecisionNoticeHandlerTest {
         verify(documentReceiver, times(1)).tryReceive(
             new DocumentWithDescription(signedDecisionNotice1, ""),
             DocumentTag.SIGNED_DECISION_NOTICE);
-        
+
         verify(documentsAppender, times(1))
             .append(existingDecisionNoticeDocumentsCaptor.capture(), eq(List.of(signedDecisionNoticeMetadata1)));
 
@@ -132,7 +139,8 @@ public class UploadSignedDecisionNoticeHandlerTest {
 
         assertEquals(1, actualExistingDecisionNoticeDocuments.size());
 
-        verify(bailCase, times(1)).write(TRIBUNAL_DOCUMENTS_WITH_METADATA, allTribunalDocs);
+        verify(bailCase, times(1)).write(TRIBUNAL_DOCUMENTS_WITH_METADATA,
+                                         List.of(new IdValue<>("1", signedDecisionNoticeMetadata1)));
         verify(bailCase).write(OUTCOME_DATE, nowWithTime.toString());
         verify(bailCase, times(1)).write(OUTCOME_STATE, State.DECISION_DECIDED);
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandlerTest.java
@@ -92,6 +92,7 @@ public class UploadSignedDecisionNoticeHandlerTest {
     @Test
     void should_add_new_document_to_the_case() {
 
+        //create empty variables
         List<IdValue<DocumentWithMetadata>> allTribunalDocs =
             List.of(
                 new IdValue<>("1", signedDecisionNoticeMetadata1)
@@ -103,24 +104,30 @@ public class UploadSignedDecisionNoticeHandlerTest {
         when(bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA)).thenReturn(
             Optional.empty());
 
+        //add description to doc
         when(documentReceiver.tryReceive(new DocumentWithDescription(signedDecisionNotice1, ""),
                                          DocumentTag.SIGNED_DECISION_NOTICE))
             .thenReturn(Optional.of(signedDecisionNoticeMetadata1));
 
+        //append doc to array
         when(documentsAppender.append(eq(new ArrayList<>()), eq(List.of(signedDecisionNoticeMetadata1))))
             .thenReturn(allTribunalDocs);
 
+        //progress through the screen
         PreSubmitCallbackResponse<BailCase> callbackResponse =
             uploadSignedDecisionNoticeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(bailCase, callbackResponse.getData());
 
+        //return data from event
         verify(bailCase, times(1)).read(UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT, Document.class);
 
+        //check tag for doc
         verify(documentReceiver, times(1)).tryReceive(
             new DocumentWithDescription(signedDecisionNotice1, ""),
             DocumentTag.SIGNED_DECISION_NOTICE);
+
 
         verify(documentsAppender, times(1))
             .append(existingDecisionNoticeDocumentsCaptor.capture(), eq(List.of(signedDecisionNoticeMetadata1)));
@@ -130,7 +137,7 @@ public class UploadSignedDecisionNoticeHandlerTest {
                 .getAllValues()
                 .get(0);
 
-        assertEquals(0, actualExistingDecisionNoticeDocuments.size());
+        assertEquals(1, actualExistingDecisionNoticeDocuments.size());
 
         verify(bailCase, times(1)).write(TRIBUNAL_DOCUMENTS_WITH_METADATA, allTribunalDocs);
         verify(bailCase).write(OUTCOME_DATE, nowWithTime.toString());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5767


### Change description ###
When upload signed decision is completed, the un-signed document should be replaced with the signed document in Documents tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
