### PR TITLE
RIA-5574 Fix to retain some values, and adding mid event callback for prev app

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
@@ -364,7 +364,6 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
         bailCase.remove(SUPPORTER_2_HAS_PASSPORT);
         bailCase.remove(SUPPORTER_2_PASSPORT);
         bailCase.remove(FINANCIAL_AMOUNT_SUPPORTER_2_UNDERTAKES);
-        bailCase.remove(HAS_FINANCIAL_COND_SUPPORTER_2);
     }
 
     private void clearFinancialSupporter3Details(BailCase bailCase) {
@@ -383,7 +382,6 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
         bailCase.remove(SUPPORTER_3_HAS_PASSPORT);
         bailCase.remove(SUPPORTER_3_PASSPORT);
         bailCase.remove(FINANCIAL_AMOUNT_SUPPORTER_3_UNDERTAKES);
-        bailCase.remove(HAS_FINANCIAL_COND_SUPPORTER_3);
     }
 
     private void clearFinancialSupporter4Details(BailCase bailCase) {
@@ -402,7 +400,6 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
         bailCase.remove(SUPPORTER_4_HAS_PASSPORT);
         bailCase.remove(SUPPORTER_4_PASSPORT);
         bailCase.remove(FINANCIAL_AMOUNT_SUPPORTER_4_UNDERTAKES);
-        bailCase.remove(HAS_FINANCIAL_COND_SUPPORTER_4);
     }
 
     private void clearLegalRepDetails(BailCase bailCase) {

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandler.java
@@ -33,7 +33,8 @@ public class CaseInferenceByBailNumberHandler implements PreSubmitCallbackHandle
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
-               && callback.getEvent() == Event.START_APPLICATION;
+               && (callback.getEvent() == Event.START_APPLICATION
+               || callback.getEvent() == Event.EDIT_BAIL_APPLICATION);
     }
 
     public PreSubmitCallbackResponse<BailCase> handle(

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CaseInferenceByBailNumberHandlerTest.java
@@ -152,7 +152,8 @@ public class CaseInferenceByBailNumberHandlerTest {
                 boolean canHandle = caseInferenceByBailNumberHandler.canHandle(callbackStage, callback);
 
                 if (callbackStage == PreSubmitCallbackStage.MID_EVENT
-                    && callback.getEvent() == Event.START_APPLICATION) {
+                    && (callback.getEvent() == Event.START_APPLICATION
+                    || callback.getEvent() == Event.EDIT_BAIL_APPLICATION)) {
 
                     assertTrue(canHandle);
                 } else {


### PR DESCRIPTION
### Change description ###

To retain values for has_financial_condition values which were being cleared, and added mid event for the error message in previous application number handler.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
