### PR TITLE
RIA-5764 Add all necessary classes + tests for NoC

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.NationalityFieldValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
@@ -386,8 +387,11 @@ public enum BailCaseFieldDefinition {
     SUBMIT_NOTIFICATION_STATUS(
         "submitNotificationStatus", new TypeReference<String>() {}),
     PREVIOUS_APPLICATION_LIST(
-        "previousApplicationList", new TypeReference<DynamicList>() {})
-    ;
+        "previousApplicationList", new TypeReference<DynamicList>() {}),
+    LOCAL_AUTHORITY_POLICY(
+        "localAuthorityPolicy", new TypeReference<OrganisationPolicy>() {}),
+    CHANGE_ORGANISATION_REQUEST_FIELD(
+        "changeOrganisationRequestField", new TypeReference<ChangeOrganisationRequest>() {});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Organisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/Organisation.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Organisation {
+
+    @JsonProperty("OrganisationID")
+    private String organisationID;
+
+    @JsonProperty("OrganisationName")
+    private String organisationName;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationPolicy.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationPolicy.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganisationPolicy {
+
+    @JsonProperty("Organisation")
+    private Organisation organisation;
+
+    @JsonProperty("OrgPolicyReference")
+    private String orgPolicyReference;
+
+    @JsonProperty("OrgPolicyCaseAssignedRole")
+    private String orgPolicyCaseAssignedRole;
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -21,6 +21,7 @@ public enum Event {
     EDIT_BAIL_APPLICATION_AFTER_SUBMIT("editBailApplicationAfterSubmit"),
     MAKE_NEW_APPLICATION("makeNewApplication"),
     VIEW_PREVIOUS_APPLICATIONS("viewPreviousApplications"),
+    NOC_REQUEST("nocRequest"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/ChangeOrganisationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/ChangeOrganisationRequest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DynamicList;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChangeOrganisationRequest {
+
+    @JsonProperty("CaseRoleId")
+    private DynamicList caseRoleId;
+
+    @JsonProperty("RequestTimestamp")
+    private String requestTimestamp;
+
+    @JsonProperty("ApprovalStatus")
+    private String approvalStatus;
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdCaseAssignment;
+
+@Slf4j
+@Component
+public class ChangeRepresentationConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    private final CcdCaseAssignment ccdCaseAssignment;
+
+    public ChangeRepresentationConfirmation(
+        CcdCaseAssignment ccdCaseAssignment
+    ) {
+
+        this.ccdCaseAssignment = ccdCaseAssignment;
+    }
+
+    public boolean canHandle(
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+        return (callback.getEvent() == Event.NOC_REQUEST);
+    }
+
+    /**
+     * the confirmation message and the error message are coming from ExUI and cannot be customised.
+     */
+    public PostSubmitCallbackResponse handle(
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        try {
+            ccdCaseAssignment.applyNoc(callback);
+
+            // redundant IF-statement for now, but there'll be more IF-statements when removal of LR gets implemented
+            if (callback.getEvent() == Event.NOC_REQUEST) {
+
+                String caseReference = callback.getCaseDetails().getCaseData()
+                    .read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class).orElse("");
+
+                postSubmitResponse.setConfirmationHeader(
+                    "# You're now representing a client on case " + caseReference
+                );
+            }
+        } catch (Exception e) {
+            log.error("Unable to change representation (apply noc) for case id {} with error message: {}",
+                      callback.getCaseDetails().getId(), e.getMessage());
+
+            postSubmitResponse.setConfirmationBody(
+                "### Something went wrong\n\n"
+                + "You have not stopped representing the appellant in this appeal.\n\n"
+                + "Use the [stop representing a client](/case/IA/Bail/"
+                + callback.getCaseDetails().getId()
+                + "/trigger/removeRepresentation/removeRepresentationSingleFormPageWithComplex) feature to try again."
+            );
+        }
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepOrganisationFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepOrganisationFormatter.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Organisation;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ref.OrganisationEntityResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.ProfessionalOrganisationRetriever;
+
+@Slf4j
+@Service
+public class LegalRepOrganisationFormatter implements PreSubmitCallbackHandler<BailCase> {
+
+    private final ProfessionalOrganisationRetriever professionalOrganisationRetriever;
+
+    public LegalRepOrganisationFormatter(
+        ProfessionalOrganisationRetriever professionalOrganisationRetriever
+    ) {
+        this.professionalOrganisationRetriever = professionalOrganisationRetriever;
+    }
+
+    @Override
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<BailCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == Event.START_APPLICATION;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<BailCase> handle(PreSubmitCallbackStage callbackStage,
+                                                      Callback<BailCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final OrganisationEntityResponse organisationEntityResponse =
+            professionalOrganisationRetriever.retrieve();
+
+        if (organisationEntityResponse == null) {
+            log.warn("Data fetched from Professional Ref data is empty, case ID: {}",
+                     callback.getCaseDetails().getId());
+        }
+
+        if (organisationEntityResponse != null
+            && StringUtils.isNotBlank(organisationEntityResponse.getOrganisationIdentifier())) {
+
+            log.info("PRD endpoint called for caseId [{}] orgId[{}]",
+                     callback.getCaseDetails().getId(), organisationEntityResponse.getOrganisationIdentifier());
+
+            setupCaseCreation(callback, organisationEntityResponse.getOrganisationIdentifier());
+        }
+
+        return new PreSubmitCallbackResponse<>(callback.getCaseDetails().getCaseData());
+    }
+
+    private void setupCaseCreation(Callback<BailCase> callback, String organisationIdentifier) {
+
+        BailCase bailCase = callback.getCaseDetails().getCaseData();
+
+        final OrganisationPolicy organisationPolicy =
+            OrganisationPolicy.builder()
+                .organisation(Organisation.builder()
+                                  .organisationID(organisationIdentifier)
+                                  .build()
+                )
+                .orgPolicyCaseAssignedRole("[LEGALREPRESENTATIVE]")
+                .build();
+
+        bailCase.write(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, organisationPolicy);
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppender.java
@@ -5,16 +5,21 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsHelper;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Organisation;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ref.OrganisationEntityResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.CompanyNameProvider;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.ProfessionalOrganisationRetriever;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY;
 
 @Slf4j
 @Component
@@ -22,14 +27,17 @@ public class LegalRepresentativeDetailsAppender implements PreSubmitCallbackHand
 
     private final UserDetails userDetails;
     private final UserDetailsHelper userDetailsHelper;
+    private final ProfessionalOrganisationRetriever professionalOrganisationRetriever;
 
     private final CompanyNameProvider companyNameProvider;
 
     public LegalRepresentativeDetailsAppender(UserDetails userDetails, UserDetailsHelper userDetailsHelper,
-                                              CompanyNameProvider companyNameProvider) {
+                                              CompanyNameProvider companyNameProvider,
+                                              ProfessionalOrganisationRetriever professionalOrganisationRetriever) {
         this.userDetails = userDetails;
         this.userDetailsHelper = userDetailsHelper;
         this.companyNameProvider = companyNameProvider;
+        this.professionalOrganisationRetriever = professionalOrganisationRetriever;
     }
 
     @Override
@@ -61,8 +69,28 @@ public class LegalRepresentativeDetailsAppender implements PreSubmitCallbackHand
         if (userRoleLabel.equals(UserRoleLabel.LEGAL_REPRESENTATIVE)) {
             companyNameProvider.prepareCompanyName(callback);
             bailCase.write(BailCaseFieldDefinition.LEGAL_REP_EMAIL_ADDRESS, email);
+
+            final OrganisationEntityResponse organisationEntityResponse =
+                professionalOrganisationRetriever.retrieve();
+            setupLocalAuthorityPolicy(callback, organisationEntityResponse.getOrganisationIdentifier());
         }
 
         return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+    private void setupLocalAuthorityPolicy(Callback<BailCase> callback, String organisationIdentifier) {
+
+        BailCase bailCase = callback.getCaseDetails().getCaseData();
+
+        final OrganisationPolicy organisationPolicy =
+            OrganisationPolicy.builder()
+                .organisation(Organisation.builder()
+                                  .organisationID(organisationIdentifier)
+                                  .build()
+                )
+                .orgPolicyCaseAssignedRole("[LEGALREPRESENTATIVE]")
+                .build();
+
+        bailCase.write(LOCAL_AUTHORITY_POLICY, organisationPolicy);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignment.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignment.java
@@ -205,7 +205,8 @@ public class CcdCaseAssignment {
         return payload;
     }
 
-    private Map<String, Object> buildRevokeAccessCaseUserMap(String organisationIdentifier, long caseId, String idamUserId) {
+    private Map<String, Object> buildRevokeAccessCaseUserMap(String organisationIdentifier,
+                                                             long caseId, String idamUserId) {
         Map<String, Object> caseUser = Maps.newHashMap();
         caseUser.put("case_id", caseId);
         caseUser.put("case_role", "[CREATOR]");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignment.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignment.java
@@ -1,0 +1,225 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+
+@Slf4j
+@Service
+public class CcdCaseAssignment {
+
+    private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
+
+    private final RestTemplate restTemplate;
+    private final AuthTokenGenerator serviceAuthTokenGenerator;
+    private final UserDetailsProvider userDetailsProvider;
+    private final String ccdUrl;
+    private final String aacUrl;
+    private final String ccdAssignmentsApiPath;
+    private final String aacAssignmentsApiPath;
+    private final String applyNocAssignmentsApiPath;
+
+    public CcdCaseAssignment(RestTemplate restTemplate,
+                             AuthTokenGenerator serviceAuthTokenGenerator,
+                             UserDetailsProvider userDetailsProvider,
+                             @Value("${core_case_data_api_assignments_url}") String ccdUrl,
+                             @Value("${assign_case_access_api_url}") String aacUrl,
+                             @Value("${core_case_data_api_assignments_path}") String ccdAssignmentsApiPath,
+                             @Value("${assign_case_access_api_assignments_path}") String aacAssignmentsApiPath,
+                             @Value("${apply_noc_access_api_assignments_path}") String applyNocAssignmentsApiPath
+    ) {
+        this.restTemplate = restTemplate;
+        this.serviceAuthTokenGenerator = serviceAuthTokenGenerator;
+        this.userDetailsProvider = userDetailsProvider;
+        this.ccdUrl = ccdUrl;
+        this.aacUrl = aacUrl;
+        this.ccdAssignmentsApiPath = ccdAssignmentsApiPath;
+        this.aacAssignmentsApiPath = aacAssignmentsApiPath;
+        this.applyNocAssignmentsApiPath = applyNocAssignmentsApiPath;
+    }
+
+    public void revokeAccessToCase(
+        final Callback<BailCase> callback,
+        final String organisationIdentifier
+    ) {
+        requireNonNull(callback, "callback must not be null");
+        requireNonNull(organisationIdentifier, "organisation identifier must not be null");
+
+        final long caseId = callback.getCaseDetails().getId();
+        final String serviceAuthorizationToken = serviceAuthTokenGenerator.generate();
+        final UserDetails userDetails = userDetailsProvider.getUserDetails();
+        final String accessToken = userDetails.getAccessToken();
+        final String idamUserId = userDetails.getId();
+
+        Map<String, Object> payload = buildRevokeAccessPayload(organisationIdentifier, caseId, idamUserId);
+
+        HttpEntity<Map<String, Object>> requestEntity =
+            new HttpEntity<>(
+                payload,
+                setHeaders(serviceAuthorizationToken, accessToken)
+            );
+
+        ResponseEntity<Object> response;
+        try {
+            response = restTemplate
+                .exchange(
+                    ccdUrl + ccdAssignmentsApiPath,
+                    HttpMethod.DELETE,
+                    requestEntity,
+                    Object.class
+                );
+
+        } catch (RestClientResponseException e) {
+            throw new CcdDataIntegrationException(
+                "Couldn't revoke CCD case access for case ["
+                + callback.getCaseDetails().getId()
+                + "] using API: "
+                + ccdUrl + ccdAssignmentsApiPath,
+                e
+            );
+        }
+
+        log.info("Revoke Access. Http status received from CCD API; {} for case {}",
+                 response.getStatusCodeValue(), callback.getCaseDetails().getId());
+    }
+
+    public void assignAccessToCase(
+        final Callback<BailCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        final long caseId = callback.getCaseDetails().getId();
+        final String serviceAuthorizationToken = serviceAuthTokenGenerator.generate();
+        final UserDetails userDetails = userDetailsProvider.getUserDetails();
+        final String accessToken = userDetails.getAccessToken();
+        final String idamUserId = userDetails.getId();
+
+        Map<String, Object> payload = buildAssignAccessCaseUserMap(caseId, idamUserId);
+
+        HttpEntity<Map<String, Object>> requestEntity =
+            new HttpEntity<>(
+                payload,
+                setHeaders(serviceAuthorizationToken, accessToken)
+            );
+
+        ResponseEntity<Object> response;
+        try {
+            response = restTemplate
+                .exchange(
+                    aacUrl + aacAssignmentsApiPath,
+                    HttpMethod.POST,
+                    requestEntity,
+                    Object.class
+                );
+
+        } catch (RestClientResponseException e) {
+            throw new CcdDataIntegrationException(
+                "Couldn't set initial AAC case assignment for case ["
+                + callback.getCaseDetails().getId()
+                + "] using API: "
+                + aacUrl + aacAssignmentsApiPath,
+                e
+            );
+        }
+
+        log.info("Assign Access. Http status received from AAC API; {} for case {}",
+                 response.getStatusCodeValue(), callback.getCaseDetails().getId());
+    }
+
+    public void applyNoc(
+        final Callback<BailCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        final String serviceAuthorizationToken = serviceAuthTokenGenerator.generate();
+        final UserDetails userDetails = userDetailsProvider.getUserDetails();
+        final String accessToken = userDetails.getAccessToken();
+
+        HttpEntity<Callback<BailCase>> requestEntity =
+            new HttpEntity<>(
+                callback,
+                setHeaders(serviceAuthorizationToken, accessToken)
+            );
+
+        ResponseEntity<Object> response;
+        try {
+            response = restTemplate
+                .exchange(
+                    aacUrl + applyNocAssignmentsApiPath,
+                    HttpMethod.POST,
+                    requestEntity,
+                    Object.class
+                );
+
+        } catch (RestClientResponseException e) {
+            throw new CcdDataIntegrationException(
+                "Couldn't apply noc AAC case assignment for case ["
+                + callback.getCaseDetails().getId()
+                + "] using API: "
+                + aacUrl + applyNocAssignmentsApiPath,
+                e
+            );
+        }
+
+        log.info("Apply NoC. Http status received from AAC API; {} for case {}",
+                 response.getStatusCodeValue(), callback.getCaseDetails().getId());
+    }
+
+    public void updateLegalRepDetails() {
+
+    }
+
+    public Map<String, Object> buildRevokeAccessPayload(String organisationIdentifier, long caseId, String idamUserId) {
+        Map<String, Object> caseUser = buildRevokeAccessCaseUserMap(organisationIdentifier, caseId, idamUserId);
+
+        ArrayList<Map<String, Object>> caseUsers = new ArrayList<>();
+        caseUsers.add(caseUser);
+
+        Map<String, Object> payload = Maps.newHashMap();
+        payload.put("case_users", caseUsers);
+        return payload;
+    }
+
+    public Map<String, Object> buildAssignAccessCaseUserMap(long caseId, String idamUserId) {
+        Map<String, Object> payload = Maps.newHashMap();
+        payload.put("case_id", caseId);
+        payload.put("assignee_id", idamUserId);
+        payload.put("case_type_id", "Bail");
+        return payload;
+    }
+
+    private Map<String, Object> buildRevokeAccessCaseUserMap(String organisationIdentifier, long caseId, String idamUserId) {
+        Map<String, Object> caseUser = Maps.newHashMap();
+        caseUser.put("case_id", caseId);
+        caseUser.put("case_role", "[CREATOR]");
+        caseUser.put("organisation_id", organisationIdentifier);
+        caseUser.put("user_id", idamUserId);
+        return caseUser;
+    }
+
+    private HttpHeaders setHeaders(String serviceAuthorizationToken, String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.set(HttpHeaders.AUTHORIZATION, accessToken);
+        headers.set(SERVICE_AUTHORIZATION, serviceAuthorizationToken);
+        return headers;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataIntegrationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataIntegrationException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients;
+
+public class CcdDataIntegrationException extends RuntimeException {
+
+    public CcdDataIntegrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -120,3 +120,8 @@ launchDarkly:
 
 bailRefusalWithInDays: 28
 
+core_case_data_api_assignments_url: ${CCD_URL:http://127.0.0.1:4452}
+assign_case_access_api_url: ${AAC_URL:http://127.0.0.1:4454}
+core_case_data_api_assignments_path: "/case-users"
+assign_case_access_api_assignments_path: "/case-assignments"
+apply_noc_access_api_assignments_path: "/noc/check-noc-approval"

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -25,7 +25,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(188, BailCaseFieldDefinition.values().length);
+        assertEquals(190, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationPolicyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationPolicyTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class OrganisationPolicyTest {
+
+    private String orgPolicyReference = "some organisation policy reference";
+
+    private String orgPolicyCaseAssignedRole = "some organisation policy case assigned role";
+
+    @Mock private Organisation organisation;
+
+    private OrganisationPolicy organisationPolicy;
+
+    @BeforeEach
+    public void setUp() {
+        organisationPolicy = OrganisationPolicy.builder()
+            .organisation(organisation)
+            .orgPolicyReference(orgPolicyReference)
+            .orgPolicyCaseAssignedRole(orgPolicyCaseAssignedRole)
+            .build();
+    }
+
+    @Test
+    void should_hold_onto_values() {
+        assertThat(organisationPolicy.getOrganisation()).isEqualTo(organisation);
+        assertThat(organisationPolicy.getOrgPolicyReference()).isEqualTo(orgPolicyReference);
+        assertThat(organisationPolicy.getOrgPolicyCaseAssignedRole()).isEqualTo(orgPolicyCaseAssignedRole);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/OrganisationTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OrganisationTest {
+
+    private String organisationId = "some organisation id";
+
+    private String organisationName = "some organisation name";
+
+    private Organisation organisation;
+
+    @BeforeEach
+    public void setUp() {
+        organisation = Organisation.builder()
+            .organisationID(organisationId)
+            .organisationName(organisationName)
+            .build();
+    }
+
+    @Test
+    void should_hold_onto_values() {
+        assertThat(organisation.getOrganisationID()).isEqualTo(organisationId);
+        assertThat(organisation.getOrganisationName()).isEqualTo(organisationName);
+    }
+    
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -29,6 +29,6 @@ public class EventTest {
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(17, Event.values().length);
+        assertEquals(18, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmationTest.java
@@ -1,0 +1,134 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientResponseException;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdCaseAssignment;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class ChangeRepresentationConfirmationTest {
+
+    @Mock private Callback<BailCase> callback;
+    @Mock private CcdCaseAssignment ccdCaseAssignment;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+
+    public static final long CASE_ID = 1234567890L;
+    public static final String BAILCASE_REFERENCE_NUMBER = "1111222233334444";
+    private ChangeRepresentationConfirmation changeRepresentationConfirmation;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        changeRepresentationConfirmation = new ChangeRepresentationConfirmation(
+            ccdCaseAssignment
+        );
+    }
+
+    @Test
+    void should_apply_noc_for_change_legal_representative() {
+
+        when(callback.getEvent()).thenReturn(Event.NOC_REQUEST);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(bailCase.read(BailCaseFieldDefinition.BAIL_REFERENCE_NUMBER, String.class))
+            .thenReturn(Optional.of(BAILCASE_REFERENCE_NUMBER));
+
+        PostSubmitCallbackResponse callbackResponse =
+            changeRepresentationConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+
+        verify(ccdCaseAssignment, times(1)).applyNoc(callback);
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("# You're now representing a client on case 1111222233334444");
+
+        //assertThat(
+        //    callbackResponse.getConfirmationBody().get())
+        //    .contains("All parties will be notified.");
+    }
+
+    @Test
+    void should_handle_when_rest_exception_thrown_for_apply_noc() {
+
+        when(callback.getEvent()).thenReturn(Event.NOC_REQUEST);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(CASE_ID);
+
+        RestClientResponseException restClientResponseEx = mock(RestClientResponseException.class);
+        doThrow(restClientResponseEx).when(ccdCaseAssignment).applyNoc(callback);
+
+        PostSubmitCallbackResponse callbackResponse =
+            changeRepresentationConfirmation.handle(callback);
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("Something went wrong");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> changeRepresentationConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = changeRepresentationConfirmation.canHandle(callback);
+
+            if (event == Event.NOC_REQUEST) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> changeRepresentationConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> changeRepresentationConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepOrganisationFormatterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepOrganisationFormatterTest.java
@@ -1,0 +1,135 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Organisation;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ref.OrganisationEntityResponse;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.ProfessionalOrganisationRetriever;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class LegalRepOrganisationFormatterTest {
+
+    private LegalRepOrganisationFormatter legalRepOrganisationFormatter;
+    private String companyName = "LBC";
+    private long ccdCaseId = 12345L;
+    private String organisationIdentifier = "ZE2KIWO";
+    private OrganisationPolicy organisationPolicy;
+
+    @Mock ProfessionalOrganisationRetriever professionalOrganisationRetriever;
+    @Mock OrganisationEntityResponse organisationEntityResponse;
+
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        legalRepOrganisationFormatter = new LegalRepOrganisationFormatter(
+            professionalOrganisationRetriever
+        );
+
+        organisationPolicy =
+            OrganisationPolicy.builder()
+                .organisation(Organisation.builder()
+                                  .organisationID(organisationIdentifier)
+                                  .build()
+                )
+                .orgPolicyCaseAssignedRole("[LEGALREPRESENTATIVE]")
+                .build();
+    }
+
+    @Test
+    void should_respond_with_bail_case_with_results() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
+        when(callback.getCaseDetails().getId()).thenReturn(ccdCaseId);
+
+        when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationEntityResponse);
+        when(organisationEntityResponse.getOrganisationIdentifier()).thenReturn(organisationIdentifier);
+
+        PreSubmitCallbackResponse<BailCase> response =
+            legalRepOrganisationFormatter.handle(
+                PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
+                callback
+            );
+
+        verify(bailCase, times(1)).write(LOCAL_AUTHORITY_POLICY, organisationPolicy);
+    }
+
+    @Test
+    void should_not_write_to_local_authority_policy_if_organisation_entity_response_is_null() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
+        when(professionalOrganisationRetriever.retrieve()).thenReturn(null);
+
+        PreSubmitCallbackResponse<BailCase> response =
+            legalRepOrganisationFormatter.handle(
+                PreSubmitCallbackStage.ABOUT_TO_SUBMIT,
+                callback
+            );
+
+        assertEquals(bailCase, response.getData());
+
+        verify(bailCase, times(0)).write(LOCAL_AUTHORITY_POLICY, organisationPolicy);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = legalRepOrganisationFormatter.canHandle(callbackStage, callback);
+
+                if (event == Event.START_APPLICATION
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> legalRepOrganisationFormatter.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> legalRepOrganisationFormatter.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppenderTest.java
@@ -5,20 +5,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsHelper;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
@@ -28,6 +35,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCal
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ref.OrganisationEntityResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.CompanyNameProvider;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.ProfessionalOrganisationRetriever;
 
 @ExtendWith(MockitoExtension.class)
 class LegalRepresentativeDetailsAppenderTest {
@@ -46,16 +54,22 @@ class LegalRepresentativeDetailsAppenderTest {
     private OrganisationEntityResponse organisationResponse;
     @Mock
     CompanyNameProvider companyNameProvider;
+    @Mock
+    ProfessionalOrganisationRetriever professionalOrganisationRetriever;
+    @Captor
+    ArgumentCaptor<OrganisationPolicy> organisationPolicyArgumentCaptor;
+
 
     private LegalRepresentativeDetailsAppender legalRepresentativeDetailsAppender;
     private final String organisationName = "some company name";
     private final String legalRepEmailAddress = "john.doe@example.com";
+    private final String organisationIdentifier = "ORG1";
 
 
     @BeforeEach
     public void setUp() {
         legalRepresentativeDetailsAppender =
-            new LegalRepresentativeDetailsAppender(userDetails, userDetailsHelper, companyNameProvider);
+            new LegalRepresentativeDetailsAppender(userDetails, userDetailsHelper, companyNameProvider, professionalOrganisationRetriever);
     }
 
     @Test
@@ -67,7 +81,8 @@ class LegalRepresentativeDetailsAppenderTest {
         when(userDetails.getEmailAddress()).thenReturn(legalRepEmailAddress);
         when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
         when(organisationResponse.getName()).thenReturn(organisationName);
-
+        when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationResponse);
+        when(organisationResponse.getOrganisationIdentifier()).thenReturn(organisationIdentifier);
 
         PreSubmitCallbackResponse<BailCase> response =
             legalRepresentativeDetailsAppender.handle(ABOUT_TO_START, callback);
@@ -80,6 +95,11 @@ class LegalRepresentativeDetailsAppenderTest {
         verify(companyNameProvider, times(1)).prepareCompanyName(callback);
         assertEquals(organisationName, organisationResponse.getName());
         verify(bailCase, times(1)).write(LEGAL_REP_EMAIL_ADDRESS, legalRepEmailAddress);
+        verify(bailCase, times(1)).write(eq(LOCAL_AUTHORITY_POLICY), organisationPolicyArgumentCaptor.capture());
+
+        OrganisationPolicy expectedOrganisationPolicy = organisationPolicyArgumentCaptor.getValue();
+        assertEquals(expectedOrganisationPolicy.getOrganisation().getOrganisationID(), organisationIdentifier);
+        assertEquals(expectedOrganisationPolicy.getOrgPolicyCaseAssignedRole(), "[LEGALREPRESENTATIVE]");
     }
 
     @Test
@@ -91,7 +111,6 @@ class LegalRepresentativeDetailsAppenderTest {
         when(userDetails.getEmailAddress()).thenReturn(legalRepEmailAddress);
         when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
 
-
         PreSubmitCallbackResponse<BailCase> response =
             legalRepresentativeDetailsAppender.handle(ABOUT_TO_START, callback);
 
@@ -101,7 +120,9 @@ class LegalRepresentativeDetailsAppenderTest {
         assertThat(response.getErrors()).isEmpty();
 
         verify(companyNameProvider, times(0)).prepareCompanyName(callback);
-        verify(bailCase, times(0)).write(LEGAL_REP_EMAIL_ADDRESS, legalRepEmailAddress);
+        verify(bailCase, never()).write(LEGAL_REP_EMAIL_ADDRESS, legalRepEmailAddress);
+        verify(bailCase, never()).write(eq(LOCAL_AUTHORITY_POLICY), any());
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/LegalRepresentativeDetailsAppenderTest.java
@@ -69,7 +69,10 @@ class LegalRepresentativeDetailsAppenderTest {
     @BeforeEach
     public void setUp() {
         legalRepresentativeDetailsAppender =
-            new LegalRepresentativeDetailsAppender(userDetails, userDetailsHelper, companyNameProvider, professionalOrganisationRetriever);
+            new LegalRepresentativeDetailsAppender(userDetails,
+                                                   userDetailsHelper,
+                                                   companyNameProvider,
+                                                   professionalOrganisationRetriever);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignmentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdCaseAssignmentTest.java
@@ -1,0 +1,284 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsProvider;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+
+@ExtendWith(MockitoExtension.class)
+class CcdCaseAssignmentTest {
+
+    private CcdCaseAssignment ccdCaseAssignment;
+
+    private static final String SERVICE_TOKEN = "ABCDEF";
+    private static final String ACCESS_TOKEN = "12345";
+    private static final String IDAM_ID_OF_USER_CREATING_CASE = "TEST_ID_CREATING_CASE";
+    private final String ccdUrl = "some-host";
+    private final String aacUrl = "some-aac-host";
+    private final String ccdAssignmentsApiPath = "some-path";
+    private final String aacAssignmentsApiPath = "some-aac-path";
+    private final String nocAssignmentsApiPath = "some-noc-path";
+
+    @Mock private AuthTokenGenerator serviceAuthTokenGenerator;
+    @Mock private UserDetailsProvider userDetailsProvider;
+    @Mock private RestTemplate restTemplate;
+    @Mock private ResponseEntity<Object> responseEntity;
+
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private UserDetails userDetails;
+
+    @BeforeEach
+    public void setUp() {
+
+        ccdCaseAssignment = new CcdCaseAssignment(
+            restTemplate,
+            serviceAuthTokenGenerator,
+            userDetailsProvider,
+            ccdUrl,
+            aacUrl,
+            ccdAssignmentsApiPath,
+            aacAssignmentsApiPath,
+            nocAssignmentsApiPath);
+    }
+
+    @Test
+    void should_send_post_to_assign_ccd_case_and_receive_201() {
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(userDetails.getId()).thenReturn(IDAM_ID_OF_USER_CREATING_CASE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     anyString(),
+                     eq(HttpMethod.POST),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenReturn(responseEntity);
+
+        when(responseEntity.getStatusCodeValue()).thenReturn(HttpStatus.CREATED.value());
+
+        ccdCaseAssignment.assignAccessToCase(callback);
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_send_delete_to_revoke_ccd_case_access_and_receive_204() {
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(userDetails.getId()).thenReturn(IDAM_ID_OF_USER_CREATING_CASE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     anyString(),
+                     eq(HttpMethod.DELETE),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenReturn(responseEntity);
+
+        when(responseEntity.getStatusCodeValue()).thenReturn(HttpStatus.NO_CONTENT.value());
+
+        ccdCaseAssignment.revokeAccessToCase(callback, "some-org-identifier");
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.DELETE),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_send_post_to_apply_noc_and_receive_201() {
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     anyString(),
+                     eq(HttpMethod.POST),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenReturn(responseEntity);
+
+        when(responseEntity.getStatusCodeValue()).thenReturn(HttpStatus.CREATED.value());
+
+        ccdCaseAssignment.applyNoc(callback);
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_handle_when_rest_exception_thrown_for_set_access() {
+
+        RestClientResponseException restClientResponseEx = mock(RestClientResponseException.class);
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(userDetails.getId()).thenReturn(IDAM_ID_OF_USER_CREATING_CASE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     eq(aacUrl + aacAssignmentsApiPath),
+                     eq(HttpMethod.POST),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenThrow(restClientResponseEx);
+
+        assertThatThrownBy(() -> ccdCaseAssignment.assignAccessToCase(callback))
+            .isInstanceOf(CcdDataIntegrationException.class)
+            .hasMessage("Couldn't set initial AAC case assignment for case ["
+                        + caseDetails.getId()
+                        + "] using API: "
+                        + aacUrl
+                        + aacAssignmentsApiPath)
+            .hasCauseInstanceOf(RestClientResponseException.class);
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_handle_when_rest_exception_thrown_for_revoke_access() {
+
+        RestClientResponseException restClientResponseEx = mock(RestClientResponseException.class);
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(userDetails.getId()).thenReturn(IDAM_ID_OF_USER_CREATING_CASE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     eq(ccdUrl + ccdAssignmentsApiPath),
+                     eq(HttpMethod.DELETE),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenThrow(restClientResponseEx);
+
+        assertThatThrownBy(() -> ccdCaseAssignment.revokeAccessToCase(callback, "some-org-identifier"))
+            .isInstanceOf(CcdDataIntegrationException.class)
+            .hasMessage("Couldn't revoke CCD case access for case ["
+                        + caseDetails.getId()
+                        + "] using API: "
+                        + ccdUrl + ccdAssignmentsApiPath)
+            .hasCauseInstanceOf(RestClientResponseException.class);
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.DELETE),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_handle_when_rest_exception_thrown_for_apply_noc() {
+
+        RestClientResponseException restClientResponseEx = mock(RestClientResponseException.class);
+
+        when(serviceAuthTokenGenerator.generate()).thenReturn(SERVICE_TOKEN);
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(123L);
+
+        when(restTemplate
+                 .exchange(
+                     eq(aacUrl + nocAssignmentsApiPath),
+                     eq(HttpMethod.POST),
+                     any(HttpEntity.class),
+                     eq(Object.class)
+                 )
+        ).thenThrow(restClientResponseEx);
+
+        assertThatThrownBy(() -> ccdCaseAssignment.applyNoc(callback))
+            .isInstanceOf(CcdDataIntegrationException.class)
+            .hasMessage("Couldn't apply noc AAC case assignment for case ["
+                        + caseDetails.getId()
+                        + "] using API: "
+                        + aacUrl + nocAssignmentsApiPath)
+            .hasCauseInstanceOf(RestClientResponseException.class);
+
+        verify(restTemplate)
+            .exchange(
+                anyString(),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Object.class)
+            );
+    }
+
+    @Test
+    void should_throw_when_callback_param_is_null() {
+
+        assertThatThrownBy(() -> ccdCaseAssignment.assignAccessToCase(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5764](https://tools.hmcts.net/jira/browse/RIA-5764)


### Change description ###
- The event gets triggered from the NoC shared componed, so there's no presubmit handler.
- There's only a postsubmit handler (ChangeRepresentationConfirmation)
- The LegalRepresentativeDetailsAppender has been expanded to include the LegalAuthorityPolicy when appending the LR's details (mainly for the organizationId)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
