### PR TITLE
RIA-5621: Added handler to populate the list of previous applications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -385,6 +385,8 @@ public enum BailCaseFieldDefinition {
         "declarationOnSubmit", new TypeReference<List<String>>(){}),
     SUBMIT_NOTIFICATION_STATUS(
         "submitNotificationStatus", new TypeReference<String>() {}),
+    PREVIOUS_APPLICATION_LIST(
+        "previousApplicationList", new TypeReference<DynamicList>() {})
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -20,6 +20,7 @@ public enum Event {
     EDIT_BAIL_APPLICATION("editBailApplication"),
     EDIT_BAIL_APPLICATION_AFTER_SUBMIT("editBailApplicationAfterSubmit"),
     MAKE_NEW_APPLICATION("makeNewApplication"),
+    VIEW_PREVIOUS_APPLICATIONS("viewPreviousApplications"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandler.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.DECISION_DETAILS_DATE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.END_APPLICATION_DATE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PREVIOUS_APPLICATION_LIST;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PRIOR_APPLICATIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.VIEW_PREVIOUS_APPLICATIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.PriorApplication;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.MakeNewApplicationService;
+
+@Component
+public class PopulatePreviousApplicationsHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    private final MakeNewApplicationService makeNewApplicationService;
+
+    public PopulatePreviousApplicationsHandler(MakeNewApplicationService makeNewApplicationService) {
+        this.makeNewApplicationService = makeNewApplicationService;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == ABOUT_TO_START && callback.getEvent() == VIEW_PREVIOUS_APPLICATIONS;
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+        Optional<List<IdValue<PriorApplication>>> maybePriorApplications = bailCase.read(PRIOR_APPLICATIONS);
+
+        List<IdValue<PriorApplication>> priorApplications = maybePriorApplications.orElse(emptyList());
+
+        List<Value> previousApplicationsElements = priorApplications
+            .stream()
+            .map(idValue -> {
+                String priorCaseJson = idValue.getValue().getCaseDataJson();
+                BailCase priorCase = makeNewApplicationService
+                    .getBailCaseFromString(idValue.getValue().getCaseDataJson());
+
+                String decisionStr;
+                String decisionDateStr;
+                if (priorCaseJson.contains("recordDecisionType")) {
+                    decisionStr = "Decided ";
+                    decisionDateStr = convertDate(priorCase.read(DECISION_DETAILS_DATE, String.class).orElse(""));
+                } else if (priorCaseJson.contains("endApplicationOutcome")) {
+                    decisionStr = "Ended ";
+                    decisionDateStr = convertDate(priorCase.read(END_APPLICATION_DATE, String.class).orElse(""));
+                } else {
+                    throw new RequiredFieldMissingException("Missing Decision Details");
+                }
+
+                return new Value(idValue.getValue().getApplicationId(),
+                                 "Bail Application "
+                                     + idValue.getValue().getApplicationId()
+                                     + " - " + decisionStr + decisionDateStr);
+            })
+            .collect(Collectors.toList());
+        Collections.reverse(previousApplicationsElements);
+        DynamicList previousApplications = new DynamicList(previousApplicationsElements.get(0),
+                                                           previousApplicationsElements);
+
+        bailCase.write(PREVIOUS_APPLICATION_LIST, previousApplications);
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+    private String convertDate(String date) {
+        if (date.isEmpty()) {
+            throw new RequiredFieldMissingException("Missing Decision Date");
+        }
+        return LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE)
+            .format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandler.java
@@ -63,6 +63,12 @@ public class PopulatePreviousApplicationsHandler implements PreSubmitCallbackHan
 
         List<IdValue<PriorApplication>> priorApplications = maybePriorApplications.orElse(emptyList());
 
+        if (priorApplications.isEmpty()) {
+            PreSubmitCallbackResponse<BailCase> response = new PreSubmitCallbackResponse<>(bailCase);
+            response.addError("There is no previous application to view");
+            return response;
+        }
+
         List<Value> previousApplicationsElements = priorApplications
             .stream()
             .map(idValue -> {

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
@@ -47,16 +47,10 @@ public class MakeNewApplicationService {
 
         String nextAppId = String.valueOf(maybeExistingPriorApplication.orElse(Collections.emptyList()).size() + 1);
 
-        String previousCaseDataJson;
 
-        try {
-            previousCaseDataJson = mapper.writeValueAsString(bailCaseBefore);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Could not serialize data", e);
-        }
 
         List<IdValue<PriorApplication>> allPriorApplications = appender.append(
-            buildNewPriorApplication(nextAppId, previousCaseDataJson),
+            buildNewPriorApplication(nextAppId, bailCaseBefore),
             maybeExistingPriorApplication.orElse(Collections.emptyList()));
 
         bailCase.write(BailCaseFieldDefinition.PRIOR_APPLICATIONS, allPriorApplications);
@@ -93,11 +87,34 @@ public class MakeNewApplicationService {
         }
     }
 
-    private PriorApplication buildNewPriorApplication(String nextAppId, String bailCaseBefore) {
+    private PriorApplication buildNewPriorApplication(String nextAppId, BailCase bailCaseBefore) {
+        // Clear any application that was saved as Prior Application for this Application.
+        // We only want to store immediate previous casedetails, not the ones prior to it.
+        bailCaseBefore.clear(BailCaseFieldDefinition.PRIOR_APPLICATIONS);
+        String previousCaseDataJson;
+        try {
+            previousCaseDataJson = mapper.writeValueAsString(bailCaseBefore);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Could not serialize data", e);
+        }
+
         return new PriorApplication(
             nextAppId,
-            bailCaseBefore
+            previousCaseDataJson
         );
+    }
+
+    public BailCase getBailCaseFromString(String caseDataJson) {
+        if (caseDataJson == null || caseDataJson.isEmpty()) {
+            throw new IllegalArgumentException("CaseData (json) is missing");
+        }
+        BailCase bailCase = new BailCase();
+        try {
+            bailCase = mapper.readValue(caseDataJson, BailCase.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return bailCase;
     }
 
     private static final List<String> VALID_ABOUT_TO_START_MAKE_NEW_APPLICATION_FIELDS = List.of(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
@@ -112,7 +112,7 @@ public class MakeNewApplicationService {
         try {
             bailCase = mapper.readValue(caseDataJson, BailCase.class);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            throw new IllegalArgumentException("Could not convert data", e);
         }
         return bailCase;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -25,7 +25,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(187, BailCaseFieldDefinition.values().length);
+        assertEquals(188, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -23,11 +23,12 @@ public class EventTest {
         assertEquals("editBailApplicationAfterSubmit", Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT.toString());
         assertEquals("changeBailDirectionDueDate", Event.CHANGE_BAIL_DIRECTION_DUE_DATE.toString());
         assertEquals("makeNewApplication", Event.MAKE_NEW_APPLICATION.toString());
+        assertEquals("viewPreviousApplications", Event.VIEW_PREVIOUS_APPLICATIONS.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(16, Event.values().length);
+        assertEquals(17, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandlerTest.java
@@ -1,0 +1,196 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.VIEW_PREVIOUS_APPLICATIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.PriorApplication;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.MakeNewApplicationService;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PopulatePreviousApplicationsHandlerTest {
+
+    @Mock
+    private MakeNewApplicationService makeNewApplicationService;
+    @Mock
+    private PopulatePreviousApplicationsHandler populatePreviousApplicationsHandler;
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    @Mock
+    List<IdValue<PriorApplication>> priorApplications;
+    @Mock
+    PriorApplication priorApplication;
+    @Mock
+    BailCase priorCase;
+
+    @Captor
+    private ArgumentCaptor<DynamicList> previousApplicationListCaptor;
+
+    @BeforeEach
+    void setUp() {
+        populatePreviousApplicationsHandler = new PopulatePreviousApplicationsHandler(makeNewApplicationService);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(priorCase.read(BailCaseFieldDefinition.END_APPLICATION_DATE, String.class))
+            .thenReturn(Optional.of("2022-06-20"));
+        when(priorCase.read(BailCaseFieldDefinition.DECISION_DETAILS_DATE, String.class))
+            .thenReturn(Optional.of("2022-06-20"));
+
+    }
+
+    @Test
+    void should_append_details_for_ended_application() {
+        String caseData = "{\"endApplicationOutcome\":\"Bail dismissed without a hearing\","
+            + "\"applicantGivenNames\":\"John\",\"applicantFamilyName\":\"Smith\","
+            + "\"outcomeState\":\"applicationEnded\",\"endApplicationDate\":\"2022-06-20\"}";
+        setUpPriorApplication(caseData);
+
+        PreSubmitCallbackResponse<BailCase> response =
+            populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(response);
+        verify(bailCase, times(1))
+            .write(eq(BailCaseFieldDefinition.PREVIOUS_APPLICATION_LIST), previousApplicationListCaptor.capture());
+
+        DynamicList previousApplications = previousApplicationListCaptor.getAllValues().get(0);
+        assertTrue(previousApplications.getValue().getLabel().contains("Ended 20-06-2022"));
+    }
+
+    @Test
+    void should_append_details_for_decided_application() {
+        String caseData = "{\"recordDecisionType\":\"refused\",\"applicantGivenNames\":\"John\","
+            + "\"applicantFamilyName\":\"Smith\",\"decisionDetailsDate\":\"2022-06-20\"}";
+        setUpPriorApplication(caseData);
+
+        PreSubmitCallbackResponse<BailCase> response =
+            populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(response);
+        verify(bailCase, times(1))
+            .write(eq(BailCaseFieldDefinition.PREVIOUS_APPLICATION_LIST), previousApplicationListCaptor.capture());
+
+        DynamicList previousApplications = previousApplicationListCaptor.getAllValues().get(0);
+        assertTrue(previousApplications.getValue().getLabel().contains("Decided 20-06-2022"));
+    }
+
+
+    @Test
+    void should_throw_exception_if_decision_details_missing() {
+        String caseData = "{\"applicantGivenNames\":\"John\","
+            + "\"applicantFamilyName\":\"Smith\",\"decisionDetailsDate\":\"2022-06-20\"}";
+        setUpPriorApplication(caseData);
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Missing Decision Details")
+            .isExactlyInstanceOf(RequiredFieldMissingException.class);
+
+    }
+
+    @Test
+    void should_throw_exception_if_date_details_missing() {
+        String caseData = "{\"recordDecisionType\":\"refused\",\"applicantGivenNames\":\"John\","
+            + "\"applicantFamilyName\":\"Smith\"}";
+        setUpPriorApplication(caseData);
+
+        when(priorCase.read(BailCaseFieldDefinition.DECISION_DETAILS_DATE, String.class))
+            .thenReturn(Optional.empty());
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Missing Decision Date")
+            .isExactlyInstanceOf(RequiredFieldMissingException.class);
+    }
+
+    @Test
+    void should_handle_allowed_event() {
+        for (Event event: Event.values()) {
+            for (PreSubmitCallbackStage stage: PreSubmitCallbackStage.values()) {
+                when(callback.getEvent()).thenReturn(event);
+                boolean canHandle = populatePreviousApplicationsHandler.canHandle(stage, callback);
+                if (stage == ABOUT_TO_START && callback.getEvent() == VIEW_PREVIOUS_APPLICATIONS) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler
+            .canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler
+            .canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler
+            .handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler
+            .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void handler_throws_error_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler.handle(ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.MAKE_NEW_APPLICATION);
+        assertThatThrownBy(() -> populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback))
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+    }
+
+    private void setUpPriorApplication(String caseData) {
+        priorApplications = List.of(new IdValue<>("1", priorApplication));
+        when(priorApplication.getCaseDataJson()).thenReturn(caseData);
+        when(bailCase.read(BailCaseFieldDefinition.PRIOR_APPLICATIONS)).thenReturn(Optional.of(priorApplications));
+        when(callback.getEvent()).thenReturn(VIEW_PREVIOUS_APPLICATIONS);
+        when(makeNewApplicationService.getBailCaseFromString(caseData)).thenReturn(priorCase);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/PopulatePreviousApplicationsHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,6 +71,18 @@ public class PopulatePreviousApplicationsHandlerTest {
         when(priorCase.read(BailCaseFieldDefinition.DECISION_DETAILS_DATE, String.class))
             .thenReturn(Optional.of("2022-06-20"));
 
+    }
+
+    @Test
+    void should_error_if_empty_list() {
+        when(bailCase.read(BailCaseFieldDefinition.PRIOR_APPLICATIONS)).thenReturn(Optional.empty());
+        when(callback.getEvent()).thenReturn(VIEW_PREVIOUS_APPLICATIONS);
+        PreSubmitCallbackResponse<BailCase> response =
+            populatePreviousApplicationsHandler.handle(ABOUT_TO_START, callback);
+        assertNotNull(response);
+        assertEquals(1, response.getErrors().size());
+        assertEquals(bailCase, response.getData());
+        assertTrue(response.getErrors().contains("There is no previous application to view"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationServiceTest.java
@@ -1,5 +1,14 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_USER;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.OUTCOME_STATE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PRIOR_APPLICATIONS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_B1_FORM_DOCS;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
@@ -9,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -21,13 +31,6 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.PriorApplication;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CURRENT_USER;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.OUTCOME_STATE;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.PRIOR_APPLICATIONS;
-import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.UPLOAD_B1_FORM_DOCS;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -66,7 +69,7 @@ class MakeNewApplicationServiceTest {
     @Test
     void should_append_prior_application_to_empty_list() {
 
-        Mockito.when(priorApplicationAppender.append(Mockito.any(PriorApplication.class), Mockito.anyList()))
+        when(priorApplicationAppender.append(Mockito.any(PriorApplication.class), Mockito.anyList()))
             .thenReturn(allAppendedPriorApplications);
 
         makeNewApplicationService.appendPriorApplication(bailCase, bailCaseBefore);
@@ -85,7 +88,7 @@ class MakeNewApplicationServiceTest {
         bailCase.write(CURRENT_USER, "current_user");
         bailCase.write(OUTCOME_STATE, "applicationEnded");
 
-        Mockito.when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
 
         makeNewApplicationService.clearFieldsAboutToStart(bailCase);
         assertThat(bailCase).isEmpty();
@@ -97,7 +100,7 @@ class MakeNewApplicationServiceTest {
         bailCase.write(CURRENT_USER, "current_user");
         bailCase.write(OUTCOME_STATE, "applicationEnded");
 
-        Mockito.when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
 
         makeNewApplicationService.clearFieldsAboutToSubmit(bailCase);
         assertThat(bailCase).isEmpty();
@@ -109,7 +112,7 @@ class MakeNewApplicationServiceTest {
         bailCase.write(CURRENT_USER, null);
         bailCase.write(OUTCOME_STATE, null);
 
-        Mockito.when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
 
         makeNewApplicationService.clearFieldsAboutToSubmit(bailCase);
         assertThat(bailCase).isEmpty();
@@ -125,7 +128,7 @@ class MakeNewApplicationServiceTest {
 
         bailCase.write(UPLOAD_B1_FORM_DOCS, b1DocumentList);
 
-        Mockito.when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(userRoleLabel);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(userRoleLabel);
 
         makeNewApplicationService.clearFieldsAboutToSubmit(bailCase);
         Mockito.verify(bailCase, Mockito.times(1)).remove(UPLOAD_B1_FORM_DOCS);
@@ -140,7 +143,7 @@ class MakeNewApplicationServiceTest {
 
         bailCase.write(UPLOAD_B1_FORM_DOCS, b1DocumentList);
 
-        Mockito.when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.ADMIN_OFFICER);
 
         makeNewApplicationService.clearFieldsAboutToSubmit(bailCase);
         Mockito.verify(bailCase, Mockito.times(0)).clear(UPLOAD_B1_FORM_DOCS);
@@ -155,6 +158,24 @@ class MakeNewApplicationServiceTest {
 
         assertThatThrownBy(() -> makeNewApplicationService.appendPriorApplication(bailCase, bailCaseBefore))
             .hasMessage("Could not serialize data")
+            .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_convert_string_to_bail_case() throws JsonProcessingException {
+        String caseDataJson = "{\"endApplicationOutcome\":\"Bail dismissed without a hearing\","
+            + "\"applicantGivenNames\":\"John\",\"applicantFamilyName\":\"Smith\","
+            + "\"outcomeState\":\"applicationEnded\",\"endApplicationDate\":\"2022-06-20\"}";
+        when(mapper.readValue(caseDataJson, BailCase.class)).thenReturn(bailCase);
+        BailCase bailCase = makeNewApplicationService.getBailCaseFromString(caseDataJson);
+        assertNotNull(bailCase);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void should_throw_exception_for_empty_null_json(String json) {
+        assertThatThrownBy(() -> makeNewApplicationService.getBailCaseFromString(json))
+            .hasMessage("CaseData (json) is missing")
             .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
- Modified MakeNewApplicationService to clear previousApplicationData
  before appending the application to PriorApplication fielf.
- Added method to convert given string to BailCase.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
