### PR TITLE
Ria 5765 Don't mess with access if not LR

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmation.java
@@ -2,9 +2,12 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsHelper;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
@@ -18,11 +21,17 @@ public class BailApplicationSavedConfirmation implements PostSubmitCallbackHandl
 
     private final ProfessionalOrganisationRetriever professionalOrganisationRetriever;
     private final CcdCaseAssignment ccdCaseAssignment;
+    private UserDetails userDetails;
+    private UserDetailsHelper userDetailsHelper;
 
     public BailApplicationSavedConfirmation(ProfessionalOrganisationRetriever professionalOrganisationRetriever,
-                                            CcdCaseAssignment ccdCaseAssignment) {
+                                            CcdCaseAssignment ccdCaseAssignment,
+                                            UserDetails userDetails,
+                                            UserDetailsHelper userDetailsHelper) {
         this.professionalOrganisationRetriever = professionalOrganisationRetriever;
         this.ccdCaseAssignment = ccdCaseAssignment;
+        this.userDetails = userDetails;
+        this.userDetailsHelper = userDetailsHelper;
     }
 
     @Override
@@ -35,6 +44,8 @@ public class BailApplicationSavedConfirmation implements PostSubmitCallbackHandl
         if (!canHandle(callback)) {
             throw new IllegalStateException("Cannot handle callback");
         }
+
+        UserRoleLabel userRoleLabel = userDetailsHelper.getLoggedInUserRoleLabel(userDetails);
 
         final BailCase bailCase = callback.getCaseDetails().getCaseData();
 
@@ -53,7 +64,8 @@ public class BailApplicationSavedConfirmation implements PostSubmitCallbackHandl
         postSubmitResponse.setConfirmationHeader("# You have saved this application");
 
         if (bailCase.read(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class).isPresent()
-            && callback.getEvent() == Event.START_APPLICATION) {
+            && callback.getEvent() == Event.START_APPLICATION
+            && userRoleLabel.equals(UserRoleLabel.LEGAL_REPRESENTATIVE)) {
 
             final String organisationIdentifier =
                 professionalOrganisationRetriever

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
@@ -62,6 +62,11 @@ public class ChangeRepresentationConfirmation implements PostSubmitCallbackHandl
                 postSubmitResponse.setConfirmationHeader(
                     "# You have removed the legal representative from this case"
                 );
+
+                postSubmitResponse.setConfirmationBody(
+                    "### What happens next\n\n"
+                    + "This legal representative will no longer have access to this case."
+                );
             }
         } catch (Exception e) {
             log.error("Unable to change representation (apply noc) for case id {} with error message: {}",

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -149,7 +150,6 @@ public class BailApplicationSavedConfirmationTest {
     @Test
     void should_not_assign_and_revoke_access_to_case_when_user_is_not_LR() {
         long caseId = 1234L;
-        String organisationIdentifier = "someOrgIdentifier";
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getId()).thenReturn(caseId);
@@ -161,6 +161,6 @@ public class BailApplicationSavedConfirmationTest {
         bailApplicationSavedConfirmation.handle(callback);
 
         verify(ccdCaseAssignment, never()).assignAccessToCase(callback);
-        verify(ccdCaseAssignment, never()).revokeAccessToCase(callback, organisationIdentifier);
+        verify(ccdCaseAssignment, never()).revokeAccessToCase(any(), anyString());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmationTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,9 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.bailcaseapi.domain.UserDetailsHelper;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.OrganisationPolicy;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.UserRoleLabel;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
@@ -41,12 +46,18 @@ public class BailApplicationSavedConfirmationTest {
 
     @Mock private OrganisationEntityResponse organisationEntityResponse;
 
+    @Mock private UserDetails userDetails;
+
+    @Mock private UserDetailsHelper userDetailsHelper;
+
     private BailApplicationSavedConfirmation bailApplicationSavedConfirmation;
 
     @BeforeEach
     public void setUp() {
         bailApplicationSavedConfirmation = new BailApplicationSavedConfirmation(professionalOrganisationRetriever,
-                                                                                ccdCaseAssignment);
+                                                                                ccdCaseAssignment,
+                                                                                userDetails,
+                                                                                userDetailsHelper);
         when(callback.getEvent()).thenReturn(Event.START_APPLICATION);
     }
 
@@ -58,6 +69,7 @@ public class BailApplicationSavedConfirmationTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
         when(callback.getCaseDetails().getId()).thenReturn(caseId);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(any())).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
         when(bailCase.read(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class)).thenReturn(
             Optional.of(organisationPolicy));
         when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationEntityResponse);
@@ -94,6 +106,7 @@ public class BailApplicationSavedConfirmationTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getId()).thenReturn(caseId);
         when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(any())).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
         when(bailCase.read(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class)).thenReturn(
             Optional.of(organisationPolicy));
         when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationEntityResponse);
@@ -114,13 +127,14 @@ public class BailApplicationSavedConfirmationTest {
     }
 
     @Test
-    void should_assign_and_revoke_access_to_case() {
+    void should_assign_and_revoke_access_to_case_when_user_is_Lr() {
         long caseId = 1234L;
         String organisationIdentifier = "someOrgIdentifier";
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getId()).thenReturn(caseId);
         when(callback.getCaseDetails().getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(any())).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
         when(bailCase.read(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class)).thenReturn(
             Optional.of(organisationPolicy));
         when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationEntityResponse);
@@ -130,5 +144,23 @@ public class BailApplicationSavedConfirmationTest {
 
         verify(ccdCaseAssignment, times(1)).assignAccessToCase(callback);
         verify(ccdCaseAssignment, times(1)).revokeAccessToCase(callback, organisationIdentifier);
+    }
+
+    @Test
+    void should_not_assign_and_revoke_access_to_case_when_user_is_not_LR() {
+        long caseId = 1234L;
+        String organisationIdentifier = "someOrgIdentifier";
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getId()).thenReturn(caseId);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(bailCase);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(any())).thenReturn(UserRoleLabel.ADMIN_OFFICER);
+        when(bailCase.read(BailCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class)).thenReturn(
+            Optional.of(organisationPolicy));
+
+        bailApplicationSavedConfirmation.handle(callback);
+
+        verify(ccdCaseAssignment, never()).assignAccessToCase(callback);
+        verify(ccdCaseAssignment, never()).revokeAccessToCase(callback, organisationIdentifier);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmationTest.java
@@ -84,6 +84,11 @@ class ChangeRepresentationConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationHeader().get())
             .contains("# You have removed the legal representative from this case");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("### What happens next\n\n"
+                      + "This legal representative will no longer have access to this case.");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5765](https://tools.hmcts.net/jira/browse/RIA-5765)


### Change description ###
- When calling BailApplicationSavedConfirmation the assignment of the case should be tampered with only if it's a LR
- Add confirmation body to ChangeRepresentationConfirmation success page


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
