### PR TITLE
RIA-6156: Clear Legal Rep details after 'RemoveLR' and 'StopRepresent…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,6 +352,8 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
 
+  testImplementation group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.10.1'
+
   testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.23.2'
   testImplementation group: 'ru.lanwen.wiremock', name: 'wiremock-junit5', version: '1.3.1'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -27,5 +27,6 @@
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-25857</cve>
+    <cve>CVE-2022-38752</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContent.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CaseDataContent {
+
+    private String caseReference;
+    private Map<String, Object> data;
+    private Map<String, Object> event;
+    private String eventToken;
+    private boolean ignoreWarning;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -26,6 +26,7 @@ public enum Event {
     REMOVE_BAIL_LEGAL_REPRESENTATIVE("removeBailLegalRepresentative"),
     STOP_LEGAL_REPRESENTING("stopLegalRepresenting"),
     UPDATE_BAIL_LEGAL_REP_DETAILS("updateBailLegalRepDetails"),
+    CLEAR_LEGAL_REPRESENTATIVE_DETAILS("clearLegalRepresentativeDetails"),
 
 
     @JsonEnumDefaultValue

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetails.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class StartEventDetails {
+
+    private Event eventId;
+    private String token;
+    private CaseDetails<BailCase> caseDetails;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetails.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SubmitEventDetails {
+
+    private long id;
+    private String jurisdiction;
+    private State state;
+    private Map<String, Object> data;
+    private int callbackResponseStatusCode;
+    private String callbackResponseStatus;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/ChangeRepresentationConfirmation.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.service.CcdDataService;
 import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdCaseAssignment;
 
 @Slf4j
@@ -17,11 +18,14 @@ import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdCaseAssignment;
 public class ChangeRepresentationConfirmation implements PostSubmitCallbackHandler<BailCase> {
 
     private final CcdCaseAssignment ccdCaseAssignment;
+    private final CcdDataService ccdDataService;
 
     public ChangeRepresentationConfirmation(
-        CcdCaseAssignment ccdCaseAssignment
+        CcdCaseAssignment ccdCaseAssignment,
+        CcdDataService ccdDataService
     ) {
         this.ccdCaseAssignment = ccdCaseAssignment;
+        this.ccdDataService = ccdDataService;
     }
 
     public boolean canHandle(
@@ -60,6 +64,7 @@ public class ChangeRepresentationConfirmation implements PostSubmitCallbackHandl
             }
 
             if (callback.getEvent() == Event.REMOVE_BAIL_LEGAL_REPRESENTATIVE) {
+                ccdDataService.clearLegalRepDetails(callback);
                 postSubmitResponse.setConfirmationHeader(
                     "# You have removed the legal representative from this case"
                 );
@@ -71,6 +76,7 @@ public class ChangeRepresentationConfirmation implements PostSubmitCallbackHandl
             }
 
             if (callback.getEvent() == Event.STOP_LEGAL_REPRESENTING) {
+                ccdDataService.clearLegalRepDetails(callback);
                 postSubmitResponse.setConfirmationHeader(
                     "# You have stopped representing this client"
                 );

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataApi.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.bailcaseapi.infrastructure.config.ServiceTokenGeneratorConfiguration.SERVICE_AUTHORIZATION;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.config.FeignConfiguration;
+
+@FeignClient(
+    name = "core-case-data-api",
+    url = "${core_case_data_api_url}",
+    configuration = FeignConfiguration.class
+)
+public interface CcdDataApi {
+    String EXPERIMENTAL = "experimental=true";
+    String CONTENT_TYPE = "content-type=application/json";
+
+    @GetMapping(
+        value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/event-triggers/{etid}"
+            + "/token?ignore-warning=true",
+        headers = CONTENT_TYPE
+    )
+    StartEventDetails startEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("uid") String userId,
+        @PathVariable("jid") String jurisdiction,
+        @PathVariable("ctid") String caseType,
+        @PathVariable("cid") String id,
+        @PathVariable("etid") String eventId
+    );
+
+    @PostMapping(
+        value = "/cases/{cid}/events",
+        headers = { CONTENT_TYPE, EXPERIMENTAL })
+    SubmitEventDetails submitEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("cid") String id,
+        @RequestBody CaseDataContent requestBody
+    );
+
+    @GetMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-triggers/{etid}"
+        + "/token?ignore-warning=true", produces = "application/json", consumes = "application/json")
+    StartEventDetails startCaseCreation(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("uid") String userId,
+        @PathVariable("jid") String jurisdiction,
+        @PathVariable("ctid") String caseType,
+        @PathVariable("etid") String eventId
+    );
+
+    @PostMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases",
+        produces = {"application/json; charset=UTF-8"}, consumes = "application/json")
+    CaseDetails<BailCase> submitCaseCreation(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("uid") String userId,
+        @PathVariable("jid") String jurisdiction,
+        @PathVariable("ctid") String caseType,
+        @RequestBody CaseDataContent content
+    );
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/SystemTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/SystemTokenGenerator.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security;
+
+
+public interface SystemTokenGenerator {
+
+    String generate();
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/SystemUserProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/SystemUserProvider.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security;
+
+public interface SystemUserProvider {
+
+    String getSystemUserId(String userToken);
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemTokenGenerator.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam;
+
+import feign.FeignException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.model.idam.Token;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemTokenGenerator;
+
+@Component
+public class IdamSystemTokenGenerator implements SystemTokenGenerator {
+
+    private final String systemUserName;
+    private final String systemUserPass;
+    private final String idamRedirectUrl;
+    private final String systemUserScope;
+    private final String idamClientId;
+    private final String idamClientSecret;
+    private final IdamApi idamApi;
+
+    public IdamSystemTokenGenerator(
+        @Value("${idam.system.username}") String systemUserName,
+        @Value("${idam.system.password}") String systemUserPass,
+        @Value("${idam.redirectUrl}") String idamRedirectUrl,
+        @Value("${idam.scope}") String systemUserScope,
+        @Value("${spring.security.oauth2.client.registration.oidc.client-id}") String idamClientId,
+        @Value("${spring.security.oauth2.client.registration.oidc.client-secret}") String idamClientSecret,
+        IdamApi idamApi
+    ) {
+        this.systemUserName = systemUserName;
+        this.systemUserPass = systemUserPass;
+        this.idamRedirectUrl = idamRedirectUrl;
+        this.systemUserScope = systemUserScope;
+        this.idamClientId = idamClientId;
+        this.idamClientSecret = idamClientSecret;
+        this.idamApi = idamApi;
+    }
+
+    @Override
+    public String generate() {
+
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("grant_type", "password");
+        map.add("redirect_uri", idamRedirectUrl);
+        map.add("client_id", idamClientId);
+        map.add("client_secret", idamClientSecret);
+        map.add("username", systemUserName);
+        map.add("password", systemUserPass);
+        map.add("scope", systemUserScope);
+
+        try {
+
+            Token tokenResponse = idamApi.token(map);
+
+            return tokenResponse.getAccessToken();
+
+        } catch (FeignException ex) {
+
+            throw new IdentityManagerResponseException("Could not get system user token from IDAM", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemUserProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemUserProvider.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam;
+
+import feign.FeignException;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemUserProvider;
+
+@Component
+public class IdamSystemUserProvider implements SystemUserProvider {
+
+    private final IdamApi idamApi;
+
+    public IdamSystemUserProvider(IdamApi idamApi) {
+        this.idamApi = idamApi;
+    }
+
+    @Override
+    public String getSystemUserId(String userToken) {
+
+        try {
+
+            return idamApi.userInfo(userToken).getUid();
+
+        } catch (FeignException ex) {
+
+            throw new IdentityManagerResponseException("Could not get system user id from IDAM", ex);
+        }
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/service/CcdDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/service/CcdDataService.java
@@ -1,0 +1,137 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.service;
+
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_LEGALLY_REPRESENTED_FOR_FLAG;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY_ADDRESS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_NAME;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_PHONE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_REFERENCE;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdDataApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemUserProvider;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@Service
+@Slf4j
+public class CcdDataService {
+
+    private final CcdDataApi ccdDataApi;
+    private final SystemTokenGenerator systemTokenGenerator;
+    private final SystemUserProvider systemUserProvider;
+    private final AuthTokenGenerator serviceAuthorization;
+    private static final String CASE_TYPE = "Bail";
+
+    public CcdDataService(CcdDataApi ccdDataApi,
+                          SystemTokenGenerator systemTokenGenerator,
+                          SystemUserProvider systemUserProvider,
+                          AuthTokenGenerator serviceAuthorization) {
+
+        this.ccdDataApi = ccdDataApi;
+        this.systemTokenGenerator = systemTokenGenerator;
+        this.systemUserProvider = systemUserProvider;
+        this.serviceAuthorization = serviceAuthorization;
+    }
+
+    public SubmitEventDetails clearLegalRepDetails(Callback<BailCase> callback) {
+
+        CaseDetails<BailCase> caseDetails = callback.getCaseDetails();
+        String event = Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS.toString();
+        String caseId = String.valueOf(caseDetails.getId());
+        String jurisdiction = caseDetails.getJurisdiction();
+
+        String userToken;
+        String s2sToken;
+        String uid;
+        try {
+            userToken = "Bearer " + systemTokenGenerator.generate();
+            log.info("System user token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            s2sToken = serviceAuthorization.generate();
+            log.info("S2S token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            uid = systemUserProvider.getSystemUserId(userToken);
+            log.info("System user id has been fetched for event: {}, caseId: {}.", event, caseId);
+
+        } catch (IdentityManagerResponseException ex) {
+
+            log.error("Unauthorized access to getCaseById", ex.getMessage());
+            throw new IdentityManagerResponseException(ex.getMessage(), ex);
+        }
+
+        // Get case details by Id
+        final StartEventDetails startEventDetails = getCase(userToken, s2sToken, uid, jurisdiction, CASE_TYPE, caseId);
+        log.info("Case details found for the caseId: {}", caseId);
+
+        if (isLegalRepDetailsMissing(startEventDetails.getCaseDetails().getCaseData())) {
+
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                              "Legal Rep Details not found for the caseId: " + caseId);
+        }
+
+        // Clear Legal Rep Details
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(LEGAL_REP_NAME.value(), "");
+        caseData.put(LEGAL_REP_COMPANY.value(), "");
+        caseData.put(LEGAL_REP_PHONE.value(), "");
+        caseData.put(LEGAL_REP_REFERENCE.value(), "");
+        caseData.put(LEGAL_REP_COMPANY_ADDRESS.value(), "");
+        caseData.put(LEGAL_REP_EMAIL_ADDRESS.value(), "");
+        caseData.put(IS_LEGALLY_REPRESENTED_FOR_FLAG.value(), "No");
+
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("id", Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS.toString());
+
+        SubmitEventDetails submitEventDetails = submitEvent(userToken, s2sToken, caseId, caseData, eventData,
+                                                            startEventDetails.getToken(), true);
+
+        log.info("Legal Rep Details cleared for the caseId: {}, Status: {}, Message: {}", caseId,
+                 submitEventDetails.getCallbackResponseStatusCode(), submitEventDetails.getCallbackResponseStatus());
+
+        return submitEventDetails;
+    }
+
+    private StartEventDetails getCase(
+        String userToken, String s2sToken, String uid, String jurisdiction, String caseType, String caseId) {
+
+        return ccdDataApi.startEvent(userToken, s2sToken, uid, jurisdiction, caseType,
+                                     caseId, Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS.toString());
+    }
+
+    private SubmitEventDetails submitEvent(
+        String userToken, String s2sToken, String caseId, Map<String, Object> data,
+        Map<String, Object> eventData, String eventToken, boolean ignoreWarning) {
+
+        CaseDataContent request =
+            new CaseDataContent(caseId, data, eventData, eventToken, ignoreWarning);
+
+        return ccdDataApi.submitEvent(userToken, s2sToken, caseId, request);
+
+    }
+
+    private boolean isLegalRepDetailsMissing(BailCase bailCase) {
+
+        return bailCase.read(LEGAL_REP_NAME, String.class).isEmpty()
+            && bailCase.read(LEGAL_REP_EMAIL_ADDRESS, String.class).isEmpty()
+            && bailCase.read(LEGAL_REP_PHONE, String.class).isEmpty()
+            && bailCase.read(LEGAL_REP_COMPANY, String.class).isEmpty()
+            && bailCase.read(LEGAL_REP_COMPANY_ADDRESS, AddressUK.class).isEmpty()
+            && bailCase.read(LEGAL_REP_REFERENCE, String.class).isEmpty();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,8 +69,11 @@ security:
   authorisedRoles:
     - "caseworker-ia"
   roleEventAccess:
+    caseworker-ia-system:
+      - "clearLegalRepresentativeDetails"
     caseworker-caa:
       - "nocRequest"
+      - "clearLegalRepresentativeDetails"
     caseworker-approver:
       - "applyNocDecision"
     caseworker-ia-legalrep-solicitor:
@@ -161,6 +164,10 @@ hystrix:
 idam:
   baseUrl: ${OPEN_ID_IDAM_URL:http://127.0.0.1:5000}
   redirectUrl: ${IA_IDAM_REDIRECT_URI:http://localhost:3002/oauth2/callback}
+  system:
+    username: ${IA_SYSTEM_USERNAME:ia-system-user@fake.hmcts.net}
+    password: ${IA_SYSTEM_PASSWORD:something}
+  scope: "openid profile authorities acr roles create-user manage-user search-user"
   s2s-auth:
     totp_secret: ${IA_S2S_SECRET:AAAAAAAAAAAAAAAC}
     microservice: ${IA_S2S_MICROSERVICE:ia}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -25,7 +25,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(213, BailCaseFieldDefinition.values().length);
+        assertEquals(214, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/SubmitEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/SubmitEventDetailsTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+
+public class SubmitEventDetailsTest {
+    private final long id = 1234;
+    private final String jurisdiction = "IA";
+    private State state;
+    private Map<String, Object> data;
+    private final int callbackResponseStatusCode = 200;
+    private final String callbackResponseStatus = "CALLBACK_COMPLETED";
+
+    private SubmitEventDetails submitEventDetails;
+
+    @Test
+    void should_test_equals_contract() {
+
+        EqualsVerifier.simple()
+            .forClass(SubmitEventDetails.class)
+            .verify();
+    }
+
+    @Test
+    void should_hold_onto_values() {
+
+        state = State.DECISION_CONDITIONAL_BAIL;
+        data = new HashMap<>();
+        data.put("legalRepName", "");
+        data.put("legalRepPhone", "");
+
+        submitEventDetails =
+            new SubmitEventDetails(id, jurisdiction, state, data, callbackResponseStatusCode, callbackResponseStatus);
+
+        assertEquals(id, submitEventDetails.getId());
+        assertEquals(jurisdiction, submitEventDetails.getJurisdiction());
+        assertEquals(State.DECISION_CONDITIONAL_BAIL, submitEventDetails.getState());
+        assertEquals(data, submitEventDetails.getData());
+        assertEquals(callbackResponseStatusCode, submitEventDetails.getCallbackResponseStatusCode());
+        assertEquals(callbackResponseStatus, submitEventDetails.getCallbackResponseStatus());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContentTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class CaseDataContentTest {
+    private Map<String, Object> data;
+    private Map<String, Object> event;
+    private final String caseReference = "1234";
+    private final String eventToken = "eventToken";
+    private final boolean ignoreWarning = true;
+    private CaseDataContent caseDataContent;
+
+    @Test
+    void should_test_equals_contract() {
+
+        EqualsVerifier.simple()
+            .forClass(CaseDataContent.class)
+            .verify();
+    }
+
+    @Test
+    void should_hold_onto_values() {
+
+        data = new HashMap<>();
+        data.put("paymentStatus", "Success");
+        data.put("paymentReference", "RC-1234");
+
+        event = new HashMap<>();
+        event.put("id", "updatePaymentStatus");
+
+        caseDataContent =
+            new CaseDataContent(caseReference, data, event, eventToken, ignoreWarning);
+
+        assertEquals("1234", caseDataContent.getCaseReference());
+        assertEquals(data, caseDataContent.getData());
+        assertEquals("updatePaymentStatus", caseDataContent.getEvent().get("id"));
+        assertEquals("eventToken", caseDataContent.getEventToken());
+        assertEquals(true, caseDataContent.isIgnoreWarning());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -28,11 +28,12 @@ public class EventTest {
         assertEquals("applyNocDecision", Event.APPLY_NOC_DECISION.toString());
         assertEquals("stopLegalRepresenting", Event.STOP_LEGAL_REPRESENTING.toString());
         assertEquals("updateBailLegalRepDetails", Event.UPDATE_BAIL_LEGAL_REP_DETAILS.toString());
+        assertEquals("clearLegalRepresentativeDetails", Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(22, Event.values().length);
+        assertEquals(23, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetailsTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+
+@ExtendWith(MockitoExtension.class)
+class StartEventDetailsTest {
+
+    private Event eventId;
+    private String token = "eventToken";
+    private long caseId = 1234;
+    private String jurisdiction = "IA";
+
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private BailCase bailCase;
+
+    private StartEventDetails startEventDetails;
+
+    @Test
+    void should_hold_onto_values() {
+
+        eventId = Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS;
+
+        when(caseDetails.getId()).thenReturn(caseId);
+        when(caseDetails.getState()).thenReturn(State.DECISION_DECIDED);
+        when(caseDetails.getJurisdiction()).thenReturn(jurisdiction);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        startEventDetails = new StartEventDetails(eventId, token, caseDetails);
+
+        assertEquals(Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS, startEventDetails.getEventId());
+        assertEquals(token, startEventDetails.getToken());
+        assertEquals(caseId, startEventDetails.getCaseDetails().getId());
+        assertEquals(jurisdiction, startEventDetails.getCaseDetails().getJurisdiction());
+        assertEquals(State.DECISION_DECIDED, startEventDetails.getCaseDetails().getState());
+        assertEquals(bailCase, startEventDetails.getCaseDetails().getCaseData());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemTokenGeneratorTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.model.idam.Token;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class IdamSystemTokenGeneratorTest {
+
+    @Mock
+    private IdamApi idamApi;
+
+    @Mock
+    private Token token;
+
+    private String systemUserName = "systemUserName";
+    private String systemUserPass = "systemUserPass";
+    private String idamRedirectUrl = "http://idamRedirectUrl";
+    private String systemUserScope = "systemUserScope";
+    private String idamClientId = "idamClientId";
+    private String idamClientSecret = "idamClientSecret";
+
+    @Test
+    void should_return_correct_token_from_idam() {
+
+        String expectedToken = "systemUserTokenHash";
+
+        when(token.getAccessToken()).thenReturn(expectedToken);
+        when(idamApi.token(any(Map.class))).thenReturn(token);
+
+        IdamSystemTokenGenerator idamSystemTokenGenerator = new IdamSystemTokenGenerator(
+            systemUserName,
+            systemUserPass,
+            idamRedirectUrl,
+            systemUserScope,
+            idamClientId,
+            idamClientSecret,
+            idamApi
+        );
+
+        String token = idamSystemTokenGenerator.generate();
+
+        assertEquals(expectedToken, token);
+
+        ArgumentCaptor<Map<String, ?>> requestFormCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(idamApi).token(requestFormCaptor.capture());
+
+        Map<String, ?> actualRequestEntity = requestFormCaptor.getValue();
+
+        assertEquals(newArrayList("password"), actualRequestEntity.get("grant_type"));
+        assertEquals(newArrayList(idamRedirectUrl), actualRequestEntity.get("redirect_uri"));
+        assertEquals(newArrayList(idamClientId), actualRequestEntity.get("client_id"));
+        assertEquals(newArrayList(idamClientSecret), actualRequestEntity.get("client_secret"));
+        assertEquals(newArrayList(systemUserName), actualRequestEntity.get("username"));
+        assertEquals(newArrayList(systemUserPass), actualRequestEntity.get("password"));
+        assertEquals(newArrayList(systemUserScope), actualRequestEntity.get("scope"));
+
+    }
+
+    @Test
+    void should_throw_exception_when_auth_service_unavailable() {
+
+        when(idamApi.token(any(Map.class))).thenThrow(FeignException.class);
+
+        IdamSystemTokenGenerator idamSystemTokenGenerator = new IdamSystemTokenGenerator(
+            systemUserName,
+            systemUserPass,
+            idamRedirectUrl,
+            systemUserScope,
+            idamClientId,
+            idamClientSecret,
+            idamApi
+        );
+
+        IdentityManagerResponseException thrown = assertThrows(
+            IdentityManagerResponseException.class,
+            idamSystemTokenGenerator::generate
+        );
+        assertEquals("Could not get system user token from IDAM", thrown.getMessage());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemUserProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/security/idam/IdamSystemUserProviderTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.model.idam.UserInfo;
+
+@ExtendWith(MockitoExtension.class)
+class IdamSystemUserProviderTest {
+
+    @Mock
+    private IdamApi idamApi;
+
+    @Mock
+    private UserInfo userInfo;
+
+    private String token = "Bearer someHash";
+
+    @Test
+    void should_return_correct_user_id() {
+
+        String expectedUserId = "someUserID";
+        when(userInfo.getUid()).thenReturn(expectedUserId);
+        when(idamApi.userInfo(token)).thenReturn(userInfo);
+
+        IdamSystemUserProvider idamSystemUserProvider = new IdamSystemUserProvider(idamApi);
+
+        String userId = idamSystemUserProvider.getSystemUserId(token);
+
+        assertEquals(expectedUserId, userId);
+
+        verify(idamApi).userInfo(token);
+    }
+
+    @Test
+    void should_throw_exception_when_auth_service_unavailable() {
+
+        when(idamApi.userInfo(token)).thenThrow(FeignException.class);
+
+        IdamSystemUserProvider idamSystemUserProvider = new IdamSystemUserProvider(idamApi);
+
+        IdentityManagerResponseException thrown = assertThrows(
+            IdentityManagerResponseException.class,
+            () -> idamSystemUserProvider.getSystemUserId(token)
+        );
+        assertEquals("Could not get system user id from IDAM", thrown.getMessage());
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/service/CcdDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/service/CcdDataServiceTest.java
@@ -1,0 +1,219 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.IS_LEGALLY_REPRESENTED_FOR_FLAG;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY_ADDRESS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_EMAIL_ADDRESS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_NAME;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_PHONE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_REFERENCE;
+
+import feign.FeignException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdDataApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.SystemUserProvider;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+class CcdDataServiceTest {
+
+    @Mock private CcdDataApi ccdDataApi;
+    @Mock private SystemTokenGenerator systemTokenGenerator;
+    @Mock private SystemUserProvider systemUserProvider;
+    @Mock private AuthTokenGenerator serviceAuthorization;
+
+    @Mock private CaseDetails<BailCase> caseDetails;
+    @Mock private Callback<BailCase> callback;
+    @Mock private CaseDetails<BailCase> startEventCaseDetails;
+    @Mock private BailCase startEventBailCase;
+
+    private String token = "token";
+    private String serviceToken = "Bearer serviceToken";
+    private String userId = "userId";
+    private String eventToken = "eventToken";
+    private long caseId = 1234;
+    private String jurisdiction = "IA";
+    private String caseType = "Bail";
+    private String eventId = "clearLegalRepresentativeDetails";
+
+    private CcdDataService ccdDataService;
+
+    @BeforeEach
+    void setUp() {
+
+        ccdDataService =
+            new CcdDataService(ccdDataApi, systemTokenGenerator, systemUserProvider, serviceAuthorization);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(caseId);
+        when(caseDetails.getJurisdiction()).thenReturn(jurisdiction);
+
+        when(startEventCaseDetails.getCaseData()).thenReturn(startEventBailCase);
+        when(startEventBailCase.read(BailCaseFieldDefinition.LEGAL_REP_NAME, String.class))
+            .thenReturn(Optional.of("J Smith"));
+        when(startEventBailCase.read(BailCaseFieldDefinition.LEGAL_REP_PHONE, String.class))
+            .thenReturn(Optional.of("0123654"));
+        when(startEventBailCase.read(BailCaseFieldDefinition.LEGAL_REP_REFERENCE, String.class))
+            .thenReturn(Optional.of("A123"));
+        when(startEventBailCase.read(BailCaseFieldDefinition.LEGAL_REP_EMAIL_ADDRESS, String.class))
+            .thenReturn(Optional.of("smith@test.com"));
+        when(startEventBailCase.read(BailCaseFieldDefinition.IS_LEGALLY_REPRESENTED_FOR_FLAG, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+
+
+        when(systemTokenGenerator.generate()).thenReturn(token);
+        when(serviceAuthorization.generate()).thenReturn(serviceToken);
+        when(systemUserProvider.getSystemUserId("Bearer " + token)).thenReturn(userId);
+    }
+
+    @Test
+    void service_should_throw_on_unable_to_generate_system_user_token() {
+        when(systemTokenGenerator.generate()).thenThrow(IdentityManagerResponseException.class);
+        assertThrows(IdentityManagerResponseException.class, () -> systemTokenGenerator.generate());
+    }
+
+    @Test
+    void service_should_throw_on_unable_to_generate_s2s_token() {
+        when(systemTokenGenerator.generate()).thenReturn("aSystemUserToken");
+        when(serviceAuthorization.generate()).thenThrow(IdentityManagerResponseException.class);
+        assertThrows(IdentityManagerResponseException.class, () -> serviceAuthorization.generate());
+    }
+
+    @Test
+    void service_should_clear_the_lr_details_for_the_case_id() {
+        StartEventDetails startEventResponse = getStartEventResponse();
+        when(ccdDataApi.startEvent(
+            "Bearer " + token, serviceToken, userId, jurisdiction,  caseType,
+                                   String.valueOf(caseId), eventId)).thenReturn(startEventResponse);
+
+        // set CaseData for the subEvent request
+        CaseDataContent caseDataContent = getCaseDataContent();
+        when(ccdDataApi.submitEvent("Bearer " + token, serviceToken, String.valueOf(caseId),
+                                    caseDataContent)).thenReturn(getSubmitEventResponse());
+
+        SubmitEventDetails submitEventDetails =
+            ccdDataService.clearLegalRepDetails(callback);
+
+        assertNotNull(submitEventDetails);
+        assertEquals(caseId, submitEventDetails.getId());
+        assertEquals(jurisdiction, submitEventDetails.getJurisdiction());
+        assertLegalRepDetailsClear(submitEventDetails.getData());
+        assertEquals("CALLBACK_COMPLETED", submitEventDetails.getCallbackResponseStatus());
+
+        verify(ccdDataApi, times(1))
+            .startEvent("Bearer " + token, serviceToken, userId,
+                         jurisdiction,  caseType, String.valueOf(caseId), eventId);
+        verify(ccdDataApi, times(1))
+            .submitEvent("Bearer " + token, serviceToken, String.valueOf(caseId), caseDataContent);
+    }
+
+    @Test
+    void service_should_error_legal_rep_details_are_not_present() {
+
+        when(startEventBailCase.read(LEGAL_REP_NAME, String.class)).thenReturn(Optional.empty());
+        when(startEventBailCase.read(LEGAL_REP_COMPANY, String.class)).thenReturn(Optional.empty());
+        when(startEventBailCase.read(LEGAL_REP_REFERENCE, String.class)).thenReturn(Optional.empty());
+        when(startEventBailCase.read(LEGAL_REP_EMAIL_ADDRESS, String.class)).thenReturn(Optional.empty());
+        when(startEventBailCase.read(LEGAL_REP_COMPANY_ADDRESS, AddressUK.class)).thenReturn(Optional.empty());
+        when(startEventBailCase.read(LEGAL_REP_PHONE, String.class)).thenReturn(Optional.empty());
+
+        StartEventDetails startEventResponse = getStartEventResponse();
+        when(
+            ccdDataApi.startEvent(
+                "Bearer " + token, serviceToken, userId,
+                jurisdiction,  caseType, String.valueOf(caseId), eventId)).thenReturn(startEventResponse);
+
+        ResponseStatusException rse = assertThrows(
+            ResponseStatusException.class, () ->
+                ccdDataService.clearLegalRepDetails(callback));
+
+        assertThat(rse.getMessage()).contains("400 BAD_REQUEST \"Legal Rep Details not found for the caseId: 1234\"");
+
+        verify(ccdDataApi, times(1))
+            .startEvent("Bearer " + token, serviceToken, userId,
+                         jurisdiction,  caseType, String.valueOf(caseId), eventId);
+    }
+
+    @Test
+    void service_should_error_on_invalid_ccd_case_reference() {
+        when(
+            ccdDataApi.startEvent(
+                "Bearer " + token, serviceToken, userId,
+                jurisdiction,  caseType, String.valueOf(caseId), eventId)).thenThrow(FeignException.class);
+
+        assertThatThrownBy(() -> ccdDataService.clearLegalRepDetails(callback))
+            .isExactlyInstanceOf(FeignException.class);
+
+    }
+
+    private void assertLegalRepDetailsClear(Map<String, Object> data) {
+        assertEquals("", data.get(LEGAL_REP_NAME.value()));
+        assertEquals("", data.get(LEGAL_REP_COMPANY.value()));
+        assertEquals("", data.get(LEGAL_REP_PHONE.value()));
+        assertEquals("", data.get(LEGAL_REP_REFERENCE.value()));
+        assertEquals("", data.get(LEGAL_REP_COMPANY_ADDRESS.value()));
+        assertEquals("", data.get(LEGAL_REP_EMAIL_ADDRESS.value()));
+        assertEquals("No", data.get(IS_LEGALLY_REPRESENTED_FOR_FLAG.value()));
+    }
+
+    private StartEventDetails getStartEventResponse() {
+        return new StartEventDetails(Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS, eventToken, startEventCaseDetails);
+    }
+
+    private SubmitEventDetails getSubmitEventResponse() {
+        return new SubmitEventDetails(caseId, jurisdiction, State.DECISION_DECIDED, getDataWithEmptyLegalRepDetails(),
+                                      200, "CALLBACK_COMPLETED");
+    }
+
+    private CaseDataContent getCaseDataContent() {
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("id", Event.CLEAR_LEGAL_REPRESENTATIVE_DETAILS.toString());
+
+        return new CaseDataContent(String.valueOf(caseId), getDataWithEmptyLegalRepDetails(),
+                                   eventData, eventToken, true);
+    }
+
+    private Map<String, Object> getDataWithEmptyLegalRepDetails() {
+        Map<String, Object> data = new HashMap<>();
+        data.put(LEGAL_REP_NAME.value(), "");
+        data.put(LEGAL_REP_COMPANY.value(), "");
+        data.put(LEGAL_REP_PHONE.value(), "");
+        data.put(LEGAL_REP_REFERENCE.value(), "");
+        data.put(LEGAL_REP_COMPANY_ADDRESS.value(), "");
+        data.put(LEGAL_REP_EMAIL_ADDRESS.value(), "");
+        data.put(IS_LEGALLY_REPRESENTED_FOR_FLAG.value(), "No");
+        return data;
+    }
+}


### PR DESCRIPTION
…ing' event

- Added classes to enable startEvent and submitEvent from the backend.
- Allowed system user to trigger new event - clearLegalRepresentativeDetails.
- In the PostSubmitHandler, calling CcdApi to trigger ClearLegalRep event and setting all Legal Rep related fields as '' and isLEgallyRepresntedForFlag as 'No'.
