### PR TITLE
RIA-6297: Fix inflight bugs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/UploadSignedDecisionNoticeHandler.java
@@ -3,16 +3,24 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.OUTCOME_DATE;
 import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.OUTCOME_STATE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.TRIBUNAL_DOCUMENTS_WITH_METADATA;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.DocumentWithMetadata;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -54,6 +62,20 @@ public class UploadSignedDecisionNoticeHandler implements PreSubmitCallbackHandl
             callback
                 .getCaseDetails()
                 .getCaseData();
+        // For cases prior to RIA-6280, the unsigned document was saved in Tribunal Documents.
+        // For such cases, when we do upload signed decision, we still want to check if
+        // document with tag BAIL_DECISION_UNSIGNED is present, if so, remove it from the Tribunal Collection.
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingTribunalDocuments =
+            bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA);
+
+        final List<IdValue<DocumentWithMetadata>> existingTribunalDocuments =
+            maybeExistingTribunalDocuments.orElse(Collections.emptyList());
+
+        List<IdValue<DocumentWithMetadata>> allTribunalDocuments = new ArrayList<>(existingTribunalDocuments);
+        allTribunalDocuments
+            .removeIf(document -> document.getValue().getTag().equals(DocumentTag.BAIL_DECISION_UNSIGNED));
+        bailCase.write(TRIBUNAL_DOCUMENTS_WITH_METADATA, allTribunalDocuments);
+
         // By this point, we have already cleared the fields UNSIGNED_DECISION_DOCUMENTS_WITH_METADATA
         // in documents-api after pdf conversion.
         // The converted pdf is placed in UPLOAD_SIGNED_DECISION_NOTICE_DOCUMENT


### PR DESCRIPTION
- For in-flight cases, when record-decision has been done prior to RIA-6280, check if the Tribunal documents collection contains document with tag Unsigned_Decision_Notice, if present, remove the document from the collection.
