### PR TITLE
Added automatic clock cancelation on MakeNewApplication Event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -314,6 +314,8 @@ public enum BailCaseFieldDefinition {
         "addCaseNoteDocument", new TypeReference<Document>(){}),
     CASE_NOTES(
         "caseNotes", new TypeReference<List<IdValue<CaseNote>>>(){}),
+    CASE_TYPE_TTL(
+        "caseTypeTTL", new TypeReference<TTL>(){}),
     SEND_DIRECTION_DESCRIPTION(
         "sendDirectionDescription", new TypeReference<String>(){}),
     SEND_DIRECTION_LIST(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/TTL.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/TTL.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.ToString;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+
+import static java.util.Objects.requireNonNull;
+
+@ToString
+@Data
+
+public class TTL {
+
+    @JsonProperty("Suspended")
+    private YesOrNo suspended;
+    @JsonProperty("SystemTTL")
+    private String systemTTL;
+    @JsonProperty("OverrideTTL")
+    private String overrideTTL;
+
+    private TTL() {
+    }
+
+    public TTL(
+        YesOrNo suspended,
+        String systemTTL,
+        String overrideTTL
+    ) {
+        this.setSuspended(requireNonNull(suspended));
+        this.setSystemTTL(requireNonNull(systemTTL));
+        this.setOverrideTTL(requireNonNull(overrideTTL));
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -12,6 +12,7 @@ public enum Event {
     RECORD_THE_DECISION("recordTheDecision"),
     UPLOAD_SIGNED_DECISION_NOTICE("uploadSignedDecisionNotice"),
     ADD_CASE_NOTE("addCaseNote"),
+    MANAGE_CASE_TTL("manageCaseTTL"),
     SEND_BAIL_DIRECTION("sendBailDirection"),
     CHANGE_BAIL_DIRECTION_DUE_DATE("changeBailDirectionDueDate"),
     MOVE_APPLICATION_TO_DECIDED("moveApplicationToDecided"),

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ManageCaseTTLHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ManageCaseTTLHandler.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.TTL;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.CASE_TYPE_TTL;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.MAKE_NEW_APPLICATION;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event.MANAGE_CASE_TTL;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+
+@Component
+public class ManageCaseTTLHandler implements PreSubmitCallbackHandler<BailCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage.equals(ABOUT_TO_SUBMIT)
+            && (callback.getEvent().equals(MANAGE_CASE_TTL)
+            || callback.getEvent().equals(MAKE_NEW_APPLICATION));
+    }
+
+    public PreSubmitCallbackResponse<BailCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<BailCase> callback
+    )
+    {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        BailCase bailCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        TTL caseTypeTTL = bailCase
+            .read(CASE_TYPE_TTL, TTL.class)
+            .orElseThrow(() -> new IllegalStateException("caseTypeTTL is not present"));
+
+        if(callback.getEvent().equals(MAKE_NEW_APPLICATION)){
+            caseTypeTTL.setSuspended(YesOrNo.YES);
+            bailCase.write(CASE_TYPE_TTL, caseTypeTTL);
+        }
+
+        //bailCase.clear(CASE_TYPE_TTL);
+
+        return new PreSubmitCallbackResponse<>(bailCase);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/MakeNewApplicationService.java
@@ -137,6 +137,7 @@ public class MakeNewApplicationService {
         BailCaseFieldDefinition.PRIOR_APPLICATIONS.value(),
         BailCaseFieldDefinition.IS_ADMIN.value(),
         BailCaseFieldDefinition.APPLICATION_SENT_BY.value(),
+        BailCaseFieldDefinition.CASE_TYPE_TTL.value(),
         BailCaseFieldDefinition.APPLICANT_GIVEN_NAMES.value(),
         BailCaseFieldDefinition.APPLICANT_FAMILY_NAME.value(),
         BailCaseFieldDefinition.APPLICANT_DOB.value(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,7 @@ security:
       - "submitApplication"
       - "recordTheDecision"
       - "addCaseNote"
+      - "manageCaseTTL"
       - "sendBailDirection"
       - "changeBailDirectionDueDate"
       - "uploadSignedDecisionNotice"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6234

### Change description ###

When an admin/LR/HO triggered the makeNewApplication event
THEN automatically trigger ManageTTL event, so that clock will be cancelled as the case is active again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
