### PR TITLE
Ria 6234 suspend clock when making new application

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Arrays;
 import java.util.List;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.NationalityFieldValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
@@ -41,6 +42,8 @@ public enum BailCaseFieldDefinition {
         "currentCaseStateVisibleToHomeOffice", new TypeReference<String>(){}),
     CURRENT_CASE_STATE_VISIBLE_TO_ALL_USERS(
         "currentCaseStateVisibleToAllUsers", new TypeReference<String>(){}),
+    CURRENT_CASE_STATE_VISIBLE_TO_SYSTEM(
+        "currentCaseStateVisibleToSystem", new TypeReference<State>(){}),
     APPLICANT_GIVEN_NAMES(
         "applicantGivenNames", new TypeReference<String>() {}),
     APPLICANT_FAMILY_NAME(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.AddressUK;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.TTL;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 
 public enum BailCaseFieldDefinition {
@@ -437,7 +438,9 @@ public enum BailCaseFieldDefinition {
     UNSIGNED_DECISION_DOCUMENTS_WITH_METADATA(
         "unsgnDecisionDocumentWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     SIGNED_DECISION_DOCUMENTS_WITH_METADATA(
-        "signDecisionDocumentWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){})
+        "signDecisionDocumentWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    TTL(
+        "TTL", new TypeReference<TTL>() {})
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContent.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CaseDataContent {
+
+    private String caseReference;
+    private Map<String, Object> data;
+    private Map<String, Object> event;
+    private String eventToken;
+    private boolean ignoreWarning;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/Event.java
@@ -24,6 +24,7 @@ public enum Event {
     NOC_REQUEST("nocRequest"),
     APPLY_NOC_DECISION("applyNocDecision"),
     REMOVE_BAIL_LEGAL_REPRESENTATIVE("removeBailLegalRepresentative"),
+    MANAGE_CASE_TTL("manageCaseTTL"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetails.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class StartEventDetails {
+
+    private Event eventId;
+    private String token;
+    private CaseDetails<BailCase> caseDetails;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetails.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SubmitEventDetails {
+
+    private long id;
+    private String jurisdiction;
+    private State state;
+    private Map<String, Object> data;
+    private int callbackResponseStatusCode;
+    private String callbackResponseStatus;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/TTL.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/TTL.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Builder
+@Data
+public class TTL {
+
+    private String systemTTL;
+    private String overrideTTL;
+    private YesOrNo suspended;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmation.java
@@ -1,14 +1,24 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
+import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class MakeNewApplicationConfirmation implements PostSubmitCallbackHandler<BailCase> {
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public MakeNewApplicationConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     @Override
     public boolean canHandle(Callback<BailCase> callback) {
@@ -31,6 +41,16 @@ public class MakeNewApplicationConfirmation implements PostSubmitCallbackHandler
 
         postSubmitResponse.setConfirmationHeader("# You have submitted this application");
 
+        if (wasSuccessful(callback)) {
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, true);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<BailCase> callback) {
+        CaseDetails<BailCase> caseDetails = callback.getCaseDetails();
+        return !Set.of(State.APPLICATION_ENDED, State.DECISION_DECIDED).contains(caseDetails.getState());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmation.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Set;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
@@ -16,40 +13,24 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
 import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
-@Component
-public class EndApplicationConfirmation implements PostSubmitCallbackHandler<BailCase> {
+public class RecordTheDecisionConfirmation implements PostSubmitCallbackHandler<BailCase> {
 
     private final TimeToLiveDataService timeToLiveDataService;
 
-    public EndApplicationConfirmation(TimeToLiveDataService timeToLiveDataService) {
+    public RecordTheDecisionConfirmation(TimeToLiveDataService timeToLiveDataService) {
         this.timeToLiveDataService = timeToLiveDataService;
     }
 
     @Override
-    public boolean canHandle(
-        Callback<BailCase> callback
-    ) {
-
-        requireNonNull(callback, "callback must not be null");
-        return callback.getEvent() == Event.END_APPLICATION;
+    public boolean canHandle(Callback<BailCase> callback) {
+        return (callback.getEvent() == Event.RECORD_THE_DECISION);
     }
 
     @Override
-    public PostSubmitCallbackResponse handle(
-        Callback<BailCase> callback
-    ) {
+    public PostSubmitCallbackResponse handle(Callback<BailCase> callback) {
         if (!canHandle(callback)) {
             throw new IllegalStateException("Cannot handle callback");
         }
-
-        PostSubmitCallbackResponse postSubmitResponse =
-            new PostSubmitCallbackResponse();
-        postSubmitResponse.setConfirmationHeader("# You have ended the application");
-        postSubmitResponse.setConfirmationBody(
-            "#### What happens next\n\n"
-                + "A notification has been sent to all parties. "
-                + "No further action is required.<br>"
-        );
 
         BailCase bailCase = callback.getCaseDetails().getCaseData();
 
@@ -58,15 +39,15 @@ public class EndApplicationConfirmation implements PostSubmitCallbackHandler<Bai
         // So it requires manual intervention to set "ttl.suspended = NO" when starting the clock again
         if (wasSuccessful(callback) && !isClockActive(bailCase)) {
             // stop the clock
-            timeToLiveDataService.updateTheClock(callback, false);
+            timeToLiveDataService.updateTheClock(callback, true);
         }
 
-        return postSubmitResponse;
+        return new PostSubmitCallbackResponse();
     }
 
     private boolean wasSuccessful(Callback<BailCase> callback) {
-        State caseState = callback.getCaseDetails().getState();
-        return caseState.equals(State.APPLICATION_ENDED);
+        CaseDetails<BailCase> caseDetails = callback.getCaseDetails();
+        return !Set.of(State.APPLICATION_ENDED, State.DECISION_DECIDED).contains(caseDetails.getState());
     }
 
     private boolean isClockActive(BailCase bailCase) {
@@ -74,4 +55,5 @@ public class EndApplicationConfirmation implements PostSubmitCallbackHandler<Bai
             .map(ttl -> ttl.getSuspended().equals(YesOrNo.NO))
             .orElse(false);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/IdamService.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.service;
+
+import feign.FeignException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@Component
+public class IdamService {
+
+    private final String systemUserName;
+    private final String systemUserPass;
+    private final String idamRedirectUrl;
+    private final String systemUserScope;
+    private final String idamClientId;
+    private final String idamClientSecret;
+    private final IdamApi idamApi;
+
+    public IdamService(
+        @Value("${idam.ia_system_user.username}") String systemUserName,
+        @Value("${idam.ia_system_user.password}") String systemUserPass,
+        @Value("${idam.redirectUrl}") String idamRedirectUrl,
+        @Value("${idam.ia_system_user.scope}") String scope,
+        @Value("${spring.security.oauth2.client.registration.oidc.client-id}") String idamClientId,
+        @Value("${spring.security.oauth2.client.registration.oidc.client-secret}") String idamClientSecret,
+        IdamApi idamApi
+    ) {
+        this.systemUserName = systemUserName;
+        this.systemUserPass = systemUserPass;
+        this.idamRedirectUrl = idamRedirectUrl;
+        this.systemUserScope = scope;
+        this.idamClientId = idamClientId;
+        this.idamClientSecret = idamClientSecret;
+        this.idamApi = idamApi;
+    }
+
+    public String getUserToken() {
+        Map<String, String> idamAuthDetails = new ConcurrentHashMap<>();
+
+        idamAuthDetails.put("grant_type", "password");
+        idamAuthDetails.put("redirect_uri", idamRedirectUrl);
+        idamAuthDetails.put("client_id", idamClientId);
+        idamAuthDetails.put("client_secret", idamClientSecret);
+        idamAuthDetails.put("username", systemUserName);
+        idamAuthDetails.put("password", systemUserPass);
+        idamAuthDetails.put("scope", systemUserScope);
+
+        return "Bearer " + idamApi.token(idamAuthDetails).getAccessToken();
+    }
+
+    public String getSystemUserId(String userToken) {
+        try {
+            return idamApi.userInfo(userToken).getUid();
+        } catch (FeignException ex) {
+            throw new IdentityManagerResponseException("Could not get system user id from IDAM", ex);
+        }
+    }
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ccddataservice/CcdDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ccddataservice/CcdDataService.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdDataApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@Service
+@Slf4j
+public class CcdDataService {
+
+    protected final CcdDataApi ccdDataApi;
+    protected final IdamService idamService;
+    protected final AuthTokenGenerator serviceAuthorization;
+    protected static final String JURISDICTION = "IA";
+    protected static final String CASE_TYPE = "Bail";
+    protected String userToken;
+    protected String s2sToken;
+    protected String uid;
+
+    public CcdDataService(CcdDataApi ccdDataApi,
+                          IdamService idamService,
+                          AuthTokenGenerator serviceAuthorization) {
+
+        this.ccdDataApi = ccdDataApi;
+        this.idamService = idamService;
+        this.serviceAuthorization = serviceAuthorization;
+    }
+
+    protected void authorize(Event eventToAuthorize, String caseId) {
+        String event = eventToAuthorize.toString();
+
+        try {
+            userToken = idamService.getUserToken();
+            log.info("System user token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            s2sToken = serviceAuthorization.generate();
+            log.info("S2S token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            uid = idamService.getSystemUserId(userToken);
+            log.info("System user id has been fetched for event: {}, caseId: {}.", event, caseId);
+
+        } catch (IdentityManagerResponseException ex) {
+
+            log.error("CcdDataService failed to be authorized: {}", ex.getMessage());
+            throw new IdentityManagerResponseException(ex.getMessage(), ex);
+        }
+    }
+
+    protected SubmitEventDetails submitEvent(
+        String userToken,
+        String s2sToken,
+        String caseId,
+        Map<String, Object> data,
+        Map<String, Object> eventData,
+        String eventToken,
+        boolean ignoreWarning) {
+
+        CaseDataContent request =
+            new CaseDataContent(caseId, data, eventData, eventToken, ignoreWarning);
+
+        return ccdDataApi.submitEvent(userToken, s2sToken, caseId, request);
+    }
+
+    protected StartEventDetails startEvent(
+        String userToken,
+        String s2sToken,
+        String uid,
+        String jurisdiction,
+        String caseType,
+        String caseId,
+        Event event) {
+        return ccdDataApi.startEvent(userToken, s2sToken, uid, jurisdiction, caseType,
+                                     caseId, event.toString());
+    }
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ccddataservice/TimeToLiveDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ccddataservice/TimeToLiveDataService.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdDataApi;
+
+@Service
+@Slf4j
+public class TimeToLiveDataService extends CcdDataService {
+
+    public TimeToLiveDataService(CcdDataApi ccdDataApi, IdamService idamService, AuthTokenGenerator serviceAuthorization) {
+        super(ccdDataApi, idamService, serviceAuthorization);
+    }
+
+    public SubmitEventDetails updateTheClock(Callback<BailCase> callback, boolean isToBeSuspended) {
+
+        String caseId = String.valueOf(callback.getCaseDetails().getId());
+        authorize(Event.MANAGE_CASE_TTL, caseId);
+
+        StartEventDetails startEventDetails = startEvent(
+            userToken,
+            s2sToken,
+            uid,
+            JURISDICTION,
+            CASE_TYPE,
+            caseId,
+            Event.MANAGE_CASE_TTL);
+
+        // Update TTL
+        TTL ttlToBeUpdated = updateTTL(startEventDetails, isToBeSuspended);
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(BailCaseFieldDefinition.TTL.value(), ttlToBeUpdated);
+
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("id", Event.MANAGE_CASE_TTL.toString());
+
+        SubmitEventDetails submitEventDetails = submitEvent(userToken, s2sToken, caseId, caseData, eventData,
+                                                            startEventDetails.getToken(), true);
+
+        log.info("TTL updated with systemTTL: {}, overrideTTL: {}, suspended: {}",
+                 ttlToBeUpdated.getSystemTTL(),
+                 ttlToBeUpdated.getOverrideTTL(),
+                 ttlToBeUpdated.getSuspended());
+
+        return submitEventDetails;
+    }
+
+    private TTL updateTTL(StartEventDetails startEventDetails, boolean isToBeSuspended) {
+
+        TTL ttl = startEventDetails.getCaseDetails().getCaseData()
+            .read(BailCaseFieldDefinition.TTL, TTL.class)
+            .orElseThrow(() -> new IllegalStateException("TTL not present"));
+
+        if (isToBeSuspended) {
+            ttl.setSuspended(YesOrNo.YES);
+        } else {
+            ttl.setSuspended(YesOrNo.NO);
+        }
+
+        return ttl;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/clients/CcdDataApi.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.bailcaseapi.infrastructure.config.ServiceTokenGeneratorConfiguration.SERVICE_AUTHORIZATION;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.config.FeignConfiguration;
+
+@FeignClient(
+    name = "core-case-data-api",
+    url = "${core_case_data_api_url}",
+    configuration = FeignConfiguration.class
+)
+public interface CcdDataApi {
+    String EXPERIMENTAL = "experimental=true";
+    String CONTENT_TYPE = "content-type=application/json";
+
+    @GetMapping(
+        value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/event-triggers/{etid}"
+                + "/token?ignore-warning=true",
+        headers = CONTENT_TYPE
+    )
+    StartEventDetails startEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("uid") String userId,
+        @PathVariable("jid") String jurisdiction,
+        @PathVariable("ctid") String caseType,
+        @PathVariable("cid") String id,
+        @PathVariable("etid") String eventId
+    );
+
+    @PostMapping(
+        value = "/cases/{cid}/events",
+        headers = { CONTENT_TYPE, EXPERIMENTAL })
+    SubmitEventDetails submitEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("cid") String id,
+        @RequestBody CaseDataContent requestBody
+    );
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -15,7 +15,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(214, BailCaseFieldDefinition.values().length);
+        assertEquals(215, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -15,7 +15,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(213, BailCaseFieldDefinition.values().length);
+        assertEquals(214, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/CaseDataContentTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CaseDataContentTest {
+
+    private final String caseReference = "caseReference";
+    private final Map<String, Object> data = Map.of("data", "data");
+    private final Map<String, Object> event = Map.of("data", "data");
+    private final String eventToken = "eventToken";
+    private final boolean ignoreWarning = true;
+
+    private CaseDataContent caseDataContent = new CaseDataContent(
+        caseReference,
+        data,
+        event,
+        eventToken,
+        ignoreWarning);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(caseReference, caseDataContent.getCaseReference());
+        assertEquals(data, caseDataContent.getData());
+        assertEquals(event, caseDataContent.getEvent());
+        assertEquals(eventToken, caseDataContent.getEventToken());
+        assertEquals(ignoreWarning, caseDataContent.isIgnoreWarning());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/EventTest.java
@@ -26,11 +26,12 @@ public class EventTest {
         assertEquals("viewPreviousApplications", Event.VIEW_PREVIOUS_APPLICATIONS.toString());
         assertEquals("nocRequest", Event.NOC_REQUEST.toString());
         assertEquals("applyNocDecision", Event.APPLY_NOC_DECISION.toString());
+        assertEquals("manageCaseTTL", Event.MANAGE_CASE_TTL.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     void fail_if_changes_needed_after_modifying_class() {
-        assertEquals(20, Event.values().length);
+        assertEquals(21, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/StartEventDetailsTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+
+@SuppressWarnings("unchecked")
+public class StartEventDetailsTest {
+
+    private Event eventId = Event.SUBMIT_APPLICATION;
+    private String token = "token";
+    private CaseDetails<BailCase> caseDetails = mock(CaseDetails.class);
+
+    private StartEventDetails startEventDetails = new StartEventDetails(eventId, token, caseDetails);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(eventId, startEventDetails.getEventId());
+        assertEquals(token, startEventDetails.getToken());
+        assertEquals(caseDetails, startEventDetails.getCaseDetails());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/SubmitEventDetailsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SubmitEventDetailsTest {
+
+    private final long id = 1000L;
+    private final String jurisdiction = "Jurisdiction";
+    private final State state = State.APPLICATION_ENDED;
+    private Map<String, Object> data = Map.of("data", "data");
+    private final int callbackResponseStatusCode = 200;
+    private final String callbackResponseStatus = "callbackResponseStatus";
+
+    private final SubmitEventDetails submitEventDetails = new SubmitEventDetails(
+        id,
+        jurisdiction,
+        state,
+        data,
+        callbackResponseStatusCode,
+        callbackResponseStatus);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(id, submitEventDetails.getId());
+        assertEquals(jurisdiction, submitEventDetails.getJurisdiction());
+        assertEquals(state, submitEventDetails.getState());
+        assertEquals(data, submitEventDetails.getData());
+        assertEquals(callbackResponseStatusCode, submitEventDetails.getCallbackResponseStatusCode());
+        assertEquals(callbackResponseStatus, submitEventDetails.getCallbackResponseStatus());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/TtlTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ccd/field/TtlTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TtlTest {
+
+    private final String systemTTL = "2022-10-24";
+    private final String overrideTTL = "2023-10-24";
+    private final YesOrNo suspended = YesOrNo.YES;
+
+    private TTL ttl = TTL.builder()
+        .suspended(suspended)
+        .overrideTTL(overrideTTL)
+        .systemTTL(systemTTL)
+        .build();
+
+    @Test
+    void should_hold_onto_values() {
+
+        assertEquals(suspended, ttl.getSuspended());
+        assertEquals(overrideTTL, ttl.getOverrideTTL());
+        assertEquals(systemTTL, ttl.getSystemTTL());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/EndApplicationConfirmationTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -23,7 +24,11 @@ public class EndApplicationConfirmationTest {
     @Mock
     private Callback<BailCase> callback;
 
-    private final EndApplicationConfirmation endApplicationConfirmation = new EndApplicationConfirmation();
+    @Mock
+    private TimeToLiveDataService timeToLiveDataService;
+
+    private final EndApplicationConfirmation endApplicationConfirmation =
+        new EndApplicationConfirmation(timeToLiveDataService);
 
     @Test
     void should_handle_only_valid_event() {

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmationTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -24,9 +25,11 @@ public class MakeNewApplicationConfirmationTest {
     @Mock private CaseDetails<BailCase> caseDetails;
     private MakeNewApplicationConfirmation makeNewApplicationConfirmation;
 
+    @Mock private TimeToLiveDataService timeToLiveDataService;
+
     @BeforeEach
     public void setUp() {
-        makeNewApplicationConfirmation = new MakeNewApplicationConfirmation();
+        makeNewApplicationConfirmation = new MakeNewApplicationConfirmation(timeToLiveDataService);
         when(callback.getEvent()).thenReturn(Event.MAKE_NEW_APPLICATION);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/IdamServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/IdamServiceTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.model.idam.Token;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.model.idam.UserInfo;
+
+@ExtendWith(MockitoExtension.class)
+class IdamServiceTest {
+
+    public static final String SOME_SYSTEM_USER = "some system user";
+    public static final String SYSTEM_USER_PASS = "some system user password";
+    public static final String REDIRECT_URL = "some redirect url";
+    public static final String SCOPE = "some scope";
+    public static final String CLIENT_ID = "some client id";
+    public static final String CLIENT_SECRET = "some client secret";
+
+    @Mock
+    private IdamApi idamApi;
+    @Mock
+    private UserInfo userInfo;
+
+    private IdamService idamService;
+
+    @BeforeEach
+    void setup() {
+        idamService = new IdamService(
+            SOME_SYSTEM_USER,
+            SYSTEM_USER_PASS,
+            REDIRECT_URL,
+            SCOPE,
+            CLIENT_ID,
+            CLIENT_SECRET,
+            idamApi
+        );
+    }
+
+    @Test
+    void getUserToken() {
+
+        when(idamApi.token(anyMap())).thenReturn(new Token("some user token", SCOPE));
+
+        String actual = idamService.getUserToken();
+
+        assertThat(actual).isEqualTo("Bearer some user token");
+
+        Map<String, String> expectedIdamApiParameter = new ConcurrentHashMap<>();
+        expectedIdamApiParameter.put("grant_type", "password");
+        expectedIdamApiParameter.put("redirect_uri", REDIRECT_URL);
+        expectedIdamApiParameter.put("client_id", CLIENT_ID);
+        expectedIdamApiParameter.put("client_secret", CLIENT_SECRET);
+        expectedIdamApiParameter.put("username", SOME_SYSTEM_USER);
+        expectedIdamApiParameter.put("password", SYSTEM_USER_PASS);
+        expectedIdamApiParameter.put("scope", SCOPE);
+
+        verify(idamApi).token(eq(expectedIdamApiParameter));
+    }
+
+    @Test
+    void getSystemUserId() {
+        String userToken = "some user token";
+        when(idamApi.userInfo(userToken)).thenReturn(userInfo);
+        when(userInfo.getUid()).thenReturn("uuid");
+
+        String actual = idamService.getSystemUserId(userToken);
+        assertThat(actual).isEqualTo("uuid");
+
+        verify(idamApi, times(1)).userInfo(userToken);
+        verify(userInfo, times(1)).getUid();
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ccddataservice/TimeToLiveDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ccddataservice/TimeToLiveDataServiceTest.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure.ccddataservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
+import uk.gov.hmcts.reform.bailcaseapi.infrastructure.clients.CcdDataApi;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class TimeToLiveDataServiceTest {
+
+    @Mock
+    private CcdDataApi ccdDataApi;
+    @Mock
+    private IdamService idamService;
+    @Mock
+    private AuthTokenGenerator serviceAuthorization;
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    @Mock
+    private TTL ttl;
+    @Mock
+    private StartEventDetails startEventDetails;
+    @Mock
+    private SubmitEventDetails submitEventDetails;
+
+    private static final String USER_TOKEN = "userToken";
+    private static final String S2S_TOKEN = "s2sToken";
+    private static final String UID = "uid";
+    private static final String CASE_TYPE = "Bail";
+    private static final String JURISDICTION = "IA";
+    private static final String EVENT_TOKEN = "eventToken";
+    private static final long CASE_ID = 1;
+
+
+    private TimeToLiveDataService timeToLiveDataService;
+
+    @BeforeEach
+    void setup() {
+        timeToLiveDataService = new TimeToLiveDataService(ccdDataApi, idamService, serviceAuthorization);
+    }
+
+    @Test
+    void should_update_the_clock() {
+        when(idamService.getUserToken()).thenReturn(USER_TOKEN);
+        when(serviceAuthorization.generate()).thenReturn(S2S_TOKEN);
+        when(idamService.getSystemUserId(USER_TOKEN)).thenReturn(UID);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(caseDetails.getId()).thenReturn(CASE_ID);
+        when(bailCase.read(BailCaseFieldDefinition.TTL, TTL.class)).thenReturn(Optional.of(ttl));
+
+        when(ccdDataApi.startEvent(USER_TOKEN, S2S_TOKEN, UID, JURISDICTION, CASE_TYPE, "1", Event.MANAGE_CASE_TTL.toString()))
+            .thenReturn(startEventDetails);
+
+        when(startEventDetails.getToken()).thenReturn(EVENT_TOKEN);
+        when(startEventDetails.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+
+        CaseDataContent submitRequest = new CaseDataContent(
+            "1",
+            Map.of("TTL", ttl),
+            Map.of("id", Event.MANAGE_CASE_TTL.toString()),
+            EVENT_TOKEN,
+            true);
+
+        ArgumentCaptor<CaseDataContent> caseDataContentArgumentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
+
+        when(ccdDataApi.submitEvent(
+            eq(USER_TOKEN),
+            eq(S2S_TOKEN),
+            eq("1"),
+            caseDataContentArgumentCaptor.capture())).thenReturn(submitEventDetails);
+
+        assertEquals(submitEventDetails, timeToLiveDataService.updateTheClock(callback, true));
+        assertEquals(submitRequest, caseDataContentArgumentCaptor.getValue());
+
+        verify(ccdDataApi, times(1)).submitEvent(USER_TOKEN, S2S_TOKEN, "1", caseDataContentArgumentCaptor.getValue());
+        verify(ttl, times(1)).setSuspended(YesOrNo.YES);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6234](https://tools.hmcts.net/jira/browse/RIA-6234)


### Change description ###
- Added CcdDataApi, a feign client that communicates with ccd-data-store-api directly
- Added CcdDataService, which uses CcdDataApi. Other classes can extend when in need to interact with ccd-data-store-api directly
- Added TimeToLiveDataService, which extends from CcdDataService and is specific for TTL affairs
- Added all necessary model classes
- Added the use of timeToLieeDataService from some PostCallbackHandler to trigger the manageCaseTTL event and suspend the clock when needed
- Added the use of timeToLieeDataService from some other PostCallbackHandlers to trigger the manageCaseTTL event and re-start the clock when TTL had already been set by ccd
  - CCD will populate the TTL complex field automatically when the event has `TTLIncrement` in the definitions. However, if the clock gets suspended, the triggering of those events that should set a time-to-live only updates the date (`systemTTL`), so it's necessary to re-trigger manageCaseTTL from ia-case-api to forcefully write `suspended: NO`
- Amended old tests and added new tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
