### PR TITLE
RIA-6445 Undo programmatic TTL

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmation.java
@@ -1,24 +1,14 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
-import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
-import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class MakeNewApplicationConfirmation implements PostSubmitCallbackHandler<BailCase> {
-
-    private final TimeToLiveDataService timeToLiveDataService;
-
-    public MakeNewApplicationConfirmation(TimeToLiveDataService timeToLiveDataService) {
-        this.timeToLiveDataService = timeToLiveDataService;
-    }
 
     @Override
     public boolean canHandle(Callback<BailCase> callback) {
@@ -41,16 +31,6 @@ public class MakeNewApplicationConfirmation implements PostSubmitCallbackHandler
 
         postSubmitResponse.setConfirmationHeader("# You have submitted this application");
 
-        if (wasSuccessful(callback)) {
-            // stop the clock
-            timeToLiveDataService.updateTheClock(callback, true);
-        }
-
         return postSubmitResponse;
-    }
-
-    private boolean wasSuccessful(Callback<BailCase> callback) {
-        CaseDetails<BailCase> caseDetails = callback.getCaseDetails();
-        return !Set.of(State.APPLICATION_ENDED, State.DECISION_DECIDED).contains(caseDetails.getState());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmation.java
@@ -1,24 +1,12 @@
 package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.TTL;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PostSubmitCallbackHandler;
-import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 public class RecordTheDecisionConfirmation implements PostSubmitCallbackHandler<BailCase> {
-
-    private final TimeToLiveDataService timeToLiveDataService;
-
-    public RecordTheDecisionConfirmation(TimeToLiveDataService timeToLiveDataService) {
-        this.timeToLiveDataService = timeToLiveDataService;
-    }
 
     @Override
     public boolean canHandle(Callback<BailCase> callback) {
@@ -31,28 +19,6 @@ public class RecordTheDecisionConfirmation implements PostSubmitCallbackHandler<
             throw new IllegalStateException("Cannot handle callback");
         }
 
-        BailCase bailCase = callback.getCaseDetails().getCaseData();
-
-        // CCD doesn't set the "ttl.suspended" to NO (clock is active) unless it's null.
-        // When the clock has been stopped "ttl.suspended" gets populated with "YES" and isn't null anymore
-        // So it requires manual intervention to set "ttl.suspended = NO" when starting the clock again
-        if (wasSuccessful(callback) && !isClockActive(bailCase)) {
-            // stop the clock
-            timeToLiveDataService.updateTheClock(callback, false);
-        }
-
         return new PostSubmitCallbackResponse();
     }
-
-    private boolean wasSuccessful(Callback<BailCase> callback) {
-        CaseDetails<BailCase> caseDetails = callback.getCaseDetails();
-        return caseDetails.getState().equals(State.UNSIGNED_DECISION);
-    }
-
-    private boolean isClockActive(BailCase bailCase) {
-        return bailCase.read(BailCaseFieldDefinition.TTL, TTL.class)
-            .map(ttl -> ttl.getSuspended().equals(YesOrNo.NO))
-            .orElse(false);
-    }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/MakeNewApplicationConfirmationTest.java
@@ -11,14 +11,10 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
-import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -29,11 +25,9 @@ public class MakeNewApplicationConfirmationTest {
     @Mock private CaseDetails<BailCase> caseDetails;
     private MakeNewApplicationConfirmation makeNewApplicationConfirmation;
 
-    @Mock private TimeToLiveDataService timeToLiveDataService;
-
     @BeforeEach
     public void setUp() {
-        makeNewApplicationConfirmation = new MakeNewApplicationConfirmation(timeToLiveDataService);
+        makeNewApplicationConfirmation = new MakeNewApplicationConfirmation();
         when(callback.getEvent()).thenReturn(Event.MAKE_NEW_APPLICATION);
     }
 
@@ -50,26 +44,6 @@ public class MakeNewApplicationConfirmationTest {
 
         assertNotNull(response.getConfirmationHeader(), "Confirmation Header is null");
         assertThat(response.getConfirmationHeader().get()).isEqualTo("# You have submitted this application");
-    }
-
-    @Test
-    void should_update_ttl_clock_if_call_successful() {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getState()).thenReturn(State.APPLICATION_SUBMITTED);
-
-        PostSubmitCallbackResponse response = makeNewApplicationConfirmation.handle(callback);
-
-        verify(timeToLiveDataService, times(1)).updateTheClock(callback, true);
-    }
-
-    @Test
-    void should_not_update_ttl_clock_if_call_successful() {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getState()).thenReturn(State.APPLICATION_ENDED); // State not updated (call unsuccessful)
-
-        PostSubmitCallbackResponse response = makeNewApplicationConfirmation.handle(callback);
-
-        verify(timeToLiveDataService, never()).updateTheClock(callback, true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/RecordTheDecisionConfirmationTest.java
@@ -3,28 +3,18 @@ package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.postsubmit;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.TTL;
-import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
-import uk.gov.hmcts.reform.bailcaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -35,17 +25,12 @@ public class RecordTheDecisionConfirmationTest {
     private CaseDetails<BailCase> caseDetails;
     @Mock
     private BailCase bailCase;
-    @Mock
-    private TTL ttl;
-
-    @Mock
-    private TimeToLiveDataService timeToLiveDataService;
 
     private RecordTheDecisionConfirmation recordTheDecisionConfirmation;
 
     @BeforeEach
     void setup() {
-        recordTheDecisionConfirmation = new RecordTheDecisionConfirmation(timeToLiveDataService);
+        recordTheDecisionConfirmation = new RecordTheDecisionConfirmation();
     }
 
     @Test
@@ -68,49 +53,6 @@ public class RecordTheDecisionConfirmationTest {
         assertThatThrownBy(() -> recordTheDecisionConfirmation.handle(callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    void should_set_ttl_not_suspended_if_necessary() {
-        when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(bailCase);
-        when(bailCase.read(BailCaseFieldDefinition.TTL, TTL.class)).thenReturn(Optional.of(ttl));
-        when(ttl.getSuspended()).thenReturn(YesOrNo.YES);
-        when(caseDetails.getState()).thenReturn(State.UNSIGNED_DECISION);
-
-        PostSubmitCallbackResponse response = recordTheDecisionConfirmation
-            .handle(callback);
-
-        verify(timeToLiveDataService, times(1)).updateTheClock(callback, false);
-    }
-
-    @Test
-    void should_not_set_ttl_suspended_property_if_already_unsuspended() {
-        when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(bailCase);
-        when(bailCase.read(BailCaseFieldDefinition.TTL, TTL.class)).thenReturn(Optional.of(ttl));
-        when(ttl.getSuspended()).thenReturn(YesOrNo.NO); // suspended=NO (TTL already active)
-        when(caseDetails.getState()).thenReturn(State.UNSIGNED_DECISION);
-
-        PostSubmitCallbackResponse response = recordTheDecisionConfirmation
-            .handle(callback);
-
-        verify(timeToLiveDataService, never()).updateTheClock(callback, false);
-    }
-
-    @Test
-    void should_not_manage_ttl_if_call_unsuccessful() {
-        when(callback.getEvent()).thenReturn(Event.RECORD_THE_DECISION);
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(bailCase);
-        when(caseDetails.getState()).thenReturn(State.APPLICATION_SUBMITTED); // Unsuccessful call: wrong state
-
-        PostSubmitCallbackResponse response = recordTheDecisionConfirmation
-            .handle(callback);
-
-        verify(timeToLiveDataService, never()).updateTheClock(callback, false);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6445](https://tools.hmcts.net/jira/browse/RIA-6445)


### Change description ###
- Undid all the changes for TTL clock suspension to accommodate the new requirements of setting TTL to 100 years instead of cancelling the clock (all managed via ccd definitions)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
