### PR TITLE
RIA-7378 - preventing application startup if secrets can't be found

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -15,7 +15,6 @@ def component = "bail-case-api"
 
 def secrets = [
   'ia-${env}': [
-
     secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
     secret('idam-secret', 'IA_IDAM_SECRET'),
     secret('s2s-secret', 'IA_S2S_SECRET'),
@@ -24,6 +23,7 @@ def secrets = [
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET'),
 
     secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
     secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -30,6 +30,7 @@ def secrets = [
     secret('docmosis-enabled', 'IA_DOCMOSIS_ENABLED'),
     secret('em-stitching-enabled', 'IA_EM_STITCHING_ENABLED'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET'),
 
     secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
     secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -22,6 +22,7 @@ def secrets = [
     secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
     secret('prof-ref-data-url', 'PROF_REF_DATA_URL'),
     secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET'),
 
     secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
     secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),

--- a/charts/ia-bail-case-api/Chart.yaml
+++ b/charts/ia-bail-case-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Bail Case API App
 name: ia-bail-case-api
 home: https://github.com/hmcts/ia-bail-case-api
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: Immigration & Asylum Team
     email: ImmigrationandAsylum@HMCTS.NET

--- a/charts/ia-bail-case-api/values.preview.template.yaml
+++ b/charts/ia-bail-case-api/values.preview.template.yaml
@@ -26,4 +26,4 @@ java:
         - s2s-microservice
         - prof-ref-data-url
         - launch-darkly-sdk-key
-
+        - ia-config-validator-secret

--- a/charts/ia-bail-case-api/values.yaml
+++ b/charts/ia-bail-case-api/values.yaml
@@ -42,3 +42,5 @@ java:
           alias: LAUNCH_DARKLY_SDK_KEY
         - name: AppInsightsInstrumentationKey
           alias: azure.application-insights.instrumentation-key
+        - name: ia-config-validator-secret
+          alias: IA_CONFIG_VALIDATOR_SECRET

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
@@ -4,9 +4,11 @@ import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.S
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +16,11 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    protected static final String CLUSTER_NAME = "CLUSTER_NAME";
+
+    @Autowired
+    private Environment environment;
 
     @Value("${ia.config.validator.secret}")
     private String iaConfigValidatorSecret;
@@ -24,12 +31,19 @@ public class ConfigValidatorAppListener implements ApplicationListener<ContextRe
     }
 
     void breakOnMissingIaConfigValidatorSecret() {
+        String clusterName = environment.getProperty(CLUSTER_NAME);
+        log.info("{} value: {}", CLUSTER_NAME, clusterName);
+        if (StringUtils.isBlank(clusterName)) {
+            log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+            return;
+        }
+
         if (StringUtils.isBlank(iaConfigValidatorSecret)) {
-            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
             throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
                 + " This is not allowed and it will break production. This is a secret value stored in a vault"
                 + " (unless running locally). Check application.yaml for further information.");
-
         }
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
@@ -35,7 +35,8 @@ public class ConfigValidatorAppListener implements ApplicationListener<ContextRe
         log.info("{} value: {}", CLUSTER_NAME, clusterName);
         if (StringUtils.isBlank(clusterName)) {
             log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
-                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.",
+                     CLUSTER_NAME);
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListener.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure;
+
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@Getter
+@Setter
+public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    @Value("${ia.config.validator.secret}")
+    private String iaConfigValidatorSecret;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        breakOnMissingIaConfigValidatorSecret();
+    }
+
+    void breakOnMissingIaConfigValidatorSecret() {
+        if (StringUtils.isBlank(iaConfigValidatorSecret)) {
+            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
+            throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
+                + " This is not allowed and it will break production. This is a secret value stored in a vault"
+                + " (unless running locally). Check application.yaml for further information.");
+
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -207,3 +207,8 @@ assign_case_access_api_url: ${AAC_URL:http://127.0.0.1:4454}
 core_case_data_api_assignments_path: "/case-users"
 assign_case_access_api_assignments_path: "/case-assignments"
 apply_noc_access_api_assignments_path: "/noc/check-noc-approval"
+
+ia:
+  config:
+    validator:
+      secret: ${IA_CONFIG_VALIDATOR_SECRET:}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -15,3 +15,4 @@ spring:
         prof-ref-data-url: PROF_REF_DATA_URL
         launch-darkly-sdk-key: LAUNCH_DARKLY_SDK_KEY
         AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
+        ia-config-validator-secret: IA_CONFIG_VALIDATOR_SECRET

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -76,8 +76,9 @@ class ConfigValidatorAppListenerTest {
         verify(env).getProperty(CLUSTER_NAME);
     }
 
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
     @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @SuppressWarnings("java:S2699")
     void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
         // Given
         configValidatorAppListener.setIaConfigValidatorSecret("secret");
@@ -91,8 +92,9 @@ class ConfigValidatorAppListenerTest {
         // I run successfully till the end
     }
 
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
     @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @SuppressWarnings("java:S2699")
     void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
         // Given
         configValidatorAppListener.setIaConfigValidatorSecret("secret");

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.bailcaseapi.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValidatorAppListenerTest {
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        // I run successfully till the end
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,47 +1,108 @@
 package uk.gov.hmcts.reform.bailcaseapi.infrastructure;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.infrastructure.ConfigValidatorAppListener.CLUSTER_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigValidatorAppListenerTest {
 
+    @Mock
+    private Environment env;
+
+    private ConfigValidatorAppListener configValidatorAppListener;
+
+    @BeforeEach
+    public void setup() {
+        configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setEnvironment(env);
+    }
+
     @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+    @SuppressWarnings("java:S2699")
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateLocal() {
         // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
         configValidatorAppListener.setIaConfigValidatorSecret(null);
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class,
-                     configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("");
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class,
-                     configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
-    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
 
         // When
         configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
 
         // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
         // I run successfully till the end
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -16,7 +16,8 @@ class ConfigValidatorAppListenerTest {
         configValidatorAppListener.setIaConfigValidatorSecret(null);
 
         // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        assertThrows(IllegalArgumentException.class,
+                     configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
     }
 
     @Test
@@ -26,7 +27,8 @@ class ConfigValidatorAppListenerTest {
         configValidatorAppListener.setIaConfigValidatorSecret("");
 
         // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        assertThrows(IllegalArgumentException.class,
+                     configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7383


### Change description ###
Adding ia.config.validator.secret to application.yaml + ConfigValidatorAppListener to check to see if secrets are being applied by azure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
