### PR TITLE
Fix redirection issue when event is triggered

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/postsubmit/BailApplicationSavedConfirmation.java
@@ -35,12 +35,12 @@ public class BailApplicationSavedConfirmation implements PostSubmitCallbackHandl
         ccdSupplementaryUpdater.setHmctsServiceIdSupplementary(callback);
 
         postSubmitResponse.setConfirmationBody(
-            "### Do this next\n\n"
+             "### Do this next\n\n"
                     + "Review and [edit the application](/case/IA/Bail/"
                     + callback.getCaseDetails().getId()
-                    + "/trigger/editBailApplication) if necessary. [Submit the application](/case/IA/Bail/"
+                    + "/trigger/editBailApplication/editBailApplicationhasPreviousBailApplication) if necessary. [Submit the application](/case/IA/Bail/"
                     + callback.getCaseDetails().getId()
-                    + "/trigger/submitApplication) when you’re ready."
+                    + "/trigger/submitApplication/submitApplicationdeclarationOnSubmit) when you’re ready."
         );
 
         postSubmitResponse.setConfirmationHeader("# You have saved this application");


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=2074&view=detail&selectedIssue=SNI-4183

### Change description ###

Currently there is a problem with the labels returned by the postsubmitcallback after a bail application is saved. Clicking on either labels (edit the application, submit application) leads to a blank page and the case details lost. 

For now a temporary workaround would be to alter the routes so that the state of the application is not lost

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
