### PR TITLE
RIA-7949 FCS contact pref mid event handler - error validation

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-fail-no-email.json
+++ b/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-fail-no-email.json
@@ -1,0 +1,86 @@
+{
+  "description": "Start the application by admin - FCS contact preferences email missing",
+  "request": {
+    "uri": "/bail/ccdMidEvent?pageId=supporterContactDetails",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7949,
+      "eventId": "startApplication",
+      "state": "applicationStarted",
+      "caseData": {
+        "template": "minimal-application-started.json",
+        "replacements": {
+          "hasFinancialCondSupporter": "Yes",
+          "hasFinancialCondSupporter2": "No",
+          "supporterGivenNames": "First Name",
+          "supporterFamilyNames": "Surname",
+          "supporterDOB": "1990-01-01",
+          "supporterAddressDetails": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE2 1JX",
+            "PostTown": "Newcastle Upon Tyne",
+            "AddressLine1": "8 Deuchar Street",
+            "AddressLine2": "",
+            "AddressLine3": ""
+          },
+          "supporterImmigration": "Permanent Resident",
+          "supporterNationality": [
+            {
+              "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+              "value": {
+                "code": "Afghan"
+              }
+            }
+          ],
+          "supporterContactDetails": [
+            "mobile"
+          ],
+          "supporterMobileNumber1": "07781122334",
+          "supporterRelation": "Parent",
+          "supporterOccupation": "Teacher",
+          "financialAmountSupporterUndertakes1": "250"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["Email is required."],
+    "caseData": {
+      "template": "minimal-application-started.json",
+      "replacements": {
+        "hasFinancialCondSupporter": "Yes",
+        "hasFinancialCondSupporter2": "No",
+        "supporterGivenNames": "First Name",
+        "supporterFamilyNames": "Surname",
+        "supporterDOB": "1990-01-01",
+        "supporterAddressDetails": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE2 1JX",
+          "PostTown": "Newcastle Upon Tyne",
+          "AddressLine1": "8 Deuchar Street",
+          "AddressLine2": "",
+          "AddressLine3": ""
+        },
+        "supporterImmigration": "Permanent Resident",
+        "supporterNationality": [
+          {
+            "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+            "value": {
+              "code": "Afghan"
+            }
+          }
+        ],
+        "supporterContactDetails": [
+          "mobile"
+        ],
+        "supporterMobileNumber1": "07781122334",
+        "supporterRelation": "Parent",
+        "supporterOccupation": "Teacher",
+        "financialAmountSupporterUndertakes1": "250"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-fail-no-phone.json
+++ b/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-fail-no-phone.json
@@ -1,0 +1,86 @@
+{
+  "description": "Start the application by admin - FCS contact preferences phone missing",
+  "request": {
+    "uri": "/bail/ccdMidEvent?pageId=supporterContactDetails",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7949,
+      "eventId": "startApplication",
+      "state": "applicationStarted",
+      "caseData": {
+        "template": "minimal-application-started.json",
+        "replacements": {
+          "hasFinancialCondSupporter": "Yes",
+          "hasFinancialCondSupporter2": "No",
+          "supporterGivenNames": "First Name",
+          "supporterFamilyNames": "Surname",
+          "supporterDOB": "1990-01-01",
+          "supporterAddressDetails": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE2 1JX",
+            "PostTown": "Newcastle Upon Tyne",
+            "AddressLine1": "8 Deuchar Street",
+            "AddressLine2": "",
+            "AddressLine3": ""
+          },
+          "supporterImmigration": "Permanent Resident",
+          "supporterNationality": [
+            {
+              "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+              "value": {
+                "code": "Afghan"
+              }
+            }
+          ],
+          "supporterContactDetails": [
+            "email"
+          ],
+          "supporterEmailAddress1": "fcs@example.com",
+          "supporterRelation": "Parent",
+          "supporterOccupation": "Teacher",
+          "financialAmountSupporterUndertakes1": "250"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["At least one phone type is required."],
+    "caseData": {
+      "template": "minimal-application-started.json",
+      "replacements": {
+        "hasFinancialCondSupporter": "Yes",
+        "hasFinancialCondSupporter2": "No",
+        "supporterGivenNames": "First Name",
+        "supporterFamilyNames": "Surname",
+        "supporterDOB": "1990-01-01",
+        "supporterAddressDetails": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE2 1JX",
+          "PostTown": "Newcastle Upon Tyne",
+          "AddressLine1": "8 Deuchar Street",
+          "AddressLine2": "",
+          "AddressLine3": ""
+        },
+        "supporterImmigration": "Permanent Resident",
+        "supporterNationality": [
+          {
+            "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+            "value": {
+              "code": "Afghan"
+            }
+          }
+        ],
+        "supporterContactDetails": [
+          "email"
+        ],
+        "supporterEmailAddress1": "fcs@example.com",
+        "supporterRelation": "Parent",
+        "supporterOccupation": "Teacher",
+        "financialAmountSupporterUndertakes1": "250"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-success.json
+++ b/src/functionalTest/resources/scenarios/RIA-7949-start-application-MidEvent-fcs-contact-preferences-success.json
@@ -1,0 +1,90 @@
+{
+  "description": "Start the application by admin - FCS contact preferences include email and phone",
+  "request": {
+    "uri": "/bail/ccdMidEvent?pageId=supporterContactDetails",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 7949,
+      "eventId": "startApplication",
+      "state": "applicationStarted",
+      "caseData": {
+        "template": "minimal-application-started.json",
+        "replacements": {
+          "hasFinancialCondSupporter": "Yes",
+          "hasFinancialCondSupporter2": "No",
+          "supporterGivenNames": "First Name",
+          "supporterFamilyNames": "Surname",
+          "supporterDOB": "1990-01-01",
+          "supporterAddressDetails": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE2 1JX",
+            "PostTown": "Newcastle Upon Tyne",
+            "AddressLine1": "8 Deuchar Street",
+            "AddressLine2": "",
+            "AddressLine3": ""
+          },
+          "supporterImmigration": "Permanent Resident",
+          "supporterNationality": [
+            {
+              "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+              "value": {
+                "code": "Afghan"
+              }
+            }
+          ],
+          "supporterContactDetails": [
+            "mobile",
+            "email"
+          ],
+          "supporterMobileNumber1": "07781122334",
+          "supporterEmailAddress1": "fcs@example.com",
+          "supporterRelation": "Parent",
+          "supporterOccupation": "Teacher",
+          "financialAmountSupporterUndertakes1": "250"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-application-started.json",
+      "replacements": {
+        "hasFinancialCondSupporter": "Yes",
+        "hasFinancialCondSupporter2": "No",
+        "supporterGivenNames": "First Name",
+        "supporterFamilyNames": "Surname",
+        "supporterDOB": "1990-01-01",
+        "supporterAddressDetails": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE2 1JX",
+          "PostTown": "Newcastle Upon Tyne",
+          "AddressLine1": "8 Deuchar Street",
+          "AddressLine2": "",
+          "AddressLine3": ""
+        },
+        "supporterImmigration": "Permanent Resident",
+        "supporterNationality": [
+          {
+            "id": "8daead00-d11b-45bf-9bc6-3d0babdba370",
+            "value": {
+              "code": "Afghan"
+            }
+          }
+        ],
+        "supporterContactDetails": [
+          "mobile",
+          "email"
+        ],
+        "supporterMobileNumber1": "07781122334",
+        "supporterEmailAddress1": "fcs@example.com",
+        "supporterRelation": "Parent",
+        "supporterOccupation": "Teacher",
+        "financialAmountSupporterUndertakes1": "250"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -99,7 +99,7 @@ public enum BailCaseFieldDefinition {
     SUPPORTER_ADDRESS_DETAILS(
         "supporterAddressDetails", new TypeReference<AddressUK>(){}),
     SUPPORTER_CONTACT_DETAILS(
-        "supporterContactDetails", new TypeReference<String>(){}),
+        "supporterContactDetails", new TypeReference<List<ContactPreference>>(){}),
     SUPPORTER_TELEPHONE_NUMBER(
         "supporterTelephoneNumber1", new TypeReference<String>(){}),
     SUPPORTER_MOBILE_NUMBER(
@@ -131,7 +131,7 @@ public enum BailCaseFieldDefinition {
     SUPPORTER_2_ADDRESS_DETAILS(
         "supporter2AddressDetails", new TypeReference<AddressUK>(){}),
     SUPPORTER_2_CONTACT_DETAILS(
-        "supporter2ContactDetails", new TypeReference<String>(){}),
+        "supporter2ContactDetails", new TypeReference<List<ContactPreference>>(){}),
     SUPPORTER_2_TELEPHONE_NUMBER(
         "supporter2TelephoneNumber1", new TypeReference<String>(){}),
     SUPPORTER_2_MOBILE_NUMBER(
@@ -163,7 +163,7 @@ public enum BailCaseFieldDefinition {
     SUPPORTER_3_ADDRESS_DETAILS(
         "supporter3AddressDetails", new TypeReference<AddressUK>(){}),
     SUPPORTER_3_CONTACT_DETAILS(
-        "supporter3ContactDetails", new TypeReference<String>(){}),
+        "supporter3ContactDetails", new TypeReference<List<ContactPreference>>(){}),
     SUPPORTER_3_TELEPHONE_NUMBER(
         "supporter3TelephoneNumber1", new TypeReference<String>(){}),
     SUPPORTER_3_MOBILE_NUMBER(
@@ -195,7 +195,7 @@ public enum BailCaseFieldDefinition {
     SUPPORTER_4_ADDRESS_DETAILS(
         "supporter4AddressDetails", new TypeReference<AddressUK>(){}),
     SUPPORTER_4_CONTACT_DETAILS(
-        "supporter4ContactDetails", new TypeReference<String>(){}),
+        "supporter4ContactDetails", new TypeReference<List<ContactPreference>>(){}),
     SUPPORTER_4_TELEPHONE_NUMBER(
         "supporter4TelephoneNumber1", new TypeReference<String>(){}),
     SUPPORTER_4_MOBILE_NUMBER(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ContactPreference.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ContactPreference.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static java.util.Arrays.stream;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
+
+public enum ContactPreference {
+
+    TELEPHONE("telephone"),
+    MOBILE("mobile"),
+    EMAIL("email");
+
+    @JsonValue
+    private String value;
+
+    ContactPreference(String value) {
+        this.value = value;
+    }
+
+    public static Optional<ContactPreference> from(
+        String value
+    ) {
+        return stream(values())
+            .filter(v -> v.getValue().equals(value))
+            .findFirst();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/FinancialConditionSupporterContactPreferenceMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/FinancialConditionSupporterContactPreferenceMidEventHandler.java
@@ -67,61 +67,30 @@ public class FinancialConditionSupporterContactPreferenceMidEventHandler impleme
         PreSubmitCallbackResponse<BailCase> response = new PreSubmitCallbackResponse<>(bailCase);
 
         String pageId = callback.getPageId();
+        String error = "";
+        Optional<List<ContactPreference>> supporterContactPreferences = Optional.empty();
 
         switch (pageId) {
-            case SUPPORTER_1_CONTACT_PREF_PAGE_ID -> {
-                Optional<List<ContactPreference>> supporter1ContactPreferences
-                    = bailCase.read(SUPPORTER_CONTACT_DETAILS);
-                String error = validateContactPreferences(supporter1ContactPreferences);
-
-                if (!error.isBlank()) {
-                    response.addError(error);
-                }
-            }
-            case SUPPORTER_2_CONTACT_PREF_PAGE_ID -> {
-                Optional<List<ContactPreference>> supporter2ContactPreferences
-                    = bailCase.read(SUPPORTER_2_CONTACT_DETAILS);
-                String error = validateContactPreferences(supporter2ContactPreferences);
-
-                if (!error.isBlank()) {
-                    response.addError(error);
-                }
-            }
-            case SUPPORTER_3_CONTACT_PREF_PAGE_ID -> {
-                Optional<List<ContactPreference>> supporter3ContactPreferences
-                    = bailCase.read(SUPPORTER_3_CONTACT_DETAILS);
-                String error = validateContactPreferences(supporter3ContactPreferences);
-
-                if (!error.isBlank()) {
-                    response.addError(error);
-                }
-            }
-            case SUPPORTER_4_CONTACT_PREF_PAGE_ID -> {
-                Optional<List<ContactPreference>> supporter4ContactPreferences
-                    = bailCase.read(SUPPORTER_4_CONTACT_DETAILS);
-                String error = validateContactPreferences(supporter4ContactPreferences);
-
-                if (!error.isBlank()) {
-                    response.addError(error);
-                }
-            }
+            case SUPPORTER_1_CONTACT_PREF_PAGE_ID -> supporterContactPreferences = bailCase.read(SUPPORTER_CONTACT_DETAILS);
+            case SUPPORTER_2_CONTACT_PREF_PAGE_ID -> supporterContactPreferences = bailCase.read(SUPPORTER_2_CONTACT_DETAILS);
+            case SUPPORTER_3_CONTACT_PREF_PAGE_ID -> supporterContactPreferences = bailCase.read(SUPPORTER_3_CONTACT_DETAILS);
+            case SUPPORTER_4_CONTACT_PREF_PAGE_ID -> supporterContactPreferences = bailCase.read(SUPPORTER_4_CONTACT_DETAILS);
             default -> {
             }
         }
 
-        return response;
-    }
-
-    private String validateContactPreferences(Optional<List<ContactPreference>> listOfContactPreferences) {
-
-        String error = "";
-
-        if (listOfContactPreferences.stream().noneMatch(list -> list.contains(EMAIL))) {
-            error = EMAIL_REQUIRED_ERROR;
-        } else if (listOfContactPreferences.stream().noneMatch(list -> list.contains(MOBILE)
-                                                                       || list.contains(TELEPHONE))) {
-            error = PHONE_REQUIRED_ERROR;
+        if (supporterContactPreferences.isPresent()) {
+            if (supporterContactPreferences.stream().noneMatch(list -> list.contains(EMAIL))) {
+                error = EMAIL_REQUIRED_ERROR;
+            } else if (supporterContactPreferences.stream().noneMatch(list -> list.contains(MOBILE)
+                                                                              || list.contains(TELEPHONE))) {
+                error = PHONE_REQUIRED_ERROR;
+            }
         }
-        return error;
+
+        if (!error.isEmpty()) {
+            response.addError(error);
+        }
+        return response;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ContactPreferenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/ContactPreferenceTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ContactPreferenceTest {
+
+    @Test
+    void has_correct_asylum_contact_preference() {
+        assertThat(ContactPreference.from("telephone").get()).isEqualByComparingTo(ContactPreference.TELEPHONE);
+        assertThat(ContactPreference.from("mobile").get()).isEqualByComparingTo(ContactPreference.MOBILE);
+        assertThat(ContactPreference.from("email").get()).isEqualByComparingTo(ContactPreference.EMAIL);
+    }
+
+    @Test
+    void returns_optional_for_unknown_contact_preference() {
+        assertThat(ContactPreference.from("unknown")).isEmpty();
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(3, ContactPreference.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/FinancialConditionSupporterContactPreferenceMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/FinancialConditionSupporterContactPreferenceMidEventHandlerTest.java
@@ -1,0 +1,307 @@
+package uk.gov.hmcts.reform.bailcaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_2_CONTACT_DETAILS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_3_CONTACT_DETAILS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_4_CONTACT_DETAILS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCaseFieldDefinition.SUPPORTER_CONTACT_DETAILS;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ContactPreference.EMAIL;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ContactPreference.MOBILE;
+import static uk.gov.hmcts.reform.bailcaseapi.domain.entities.ContactPreference.TELEPHONE;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ContactPreference;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class FinancialConditionSupporterContactPreferenceMidEventHandlerTest {
+
+    @Mock
+    private Callback<BailCase> callback;
+    @Mock
+    private CaseDetails<BailCase> caseDetails;
+    @Mock
+    private BailCase bailCase;
+    private FinancialConditionSupporterContactPreferenceMidEventHandler
+        financialConditionSupporterContactPreferenceMidEventHandler;
+
+    private static final String SUPPORTER_1_CONTACT_PREF_PAGE_ID = "supporterContactDetails";
+    private static final String SUPPORTER_2_CONTACT_PREF_PAGE_ID = "supporter2ContactDetails";
+    private static final String SUPPORTER_3_CONTACT_PREF_PAGE_ID = "supporter3ContactDetails";
+    private static final String SUPPORTER_4_CONTACT_PREF_PAGE_ID = "supporter4ContactDetails";
+    private static final String EMAIL_REQUIRED_ERROR = "Email is required.";
+    private static final String PHONE_REQUIRED_ERROR = "At least one phone type is required.";
+
+    @BeforeEach
+    public void setUp() {
+        financialConditionSupporterContactPreferenceMidEventHandler =
+            new FinancialConditionSupporterContactPreferenceMidEventHandler();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_email_error_message_when_only_telephone_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(TELEPHONE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_1_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors).contains(EMAIL_REQUIRED_ERROR);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_email_error_message_when_only_mobile_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(MOBILE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_2_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_2_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors).contains(EMAIL_REQUIRED_ERROR);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_email_error_message_when_telephone_and_mobile_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(TELEPHONE, MOBILE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_3_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_3_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors).contains(EMAIL_REQUIRED_ERROR);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_email_error_message_when_only_email_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(EMAIL);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_4_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_4_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors).contains(PHONE_REQUIRED_ERROR);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_no_errors_when_email_and_telephone_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(EMAIL, TELEPHONE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_1_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_no_errors_when_email_and_mobile_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(EMAIL, MOBILE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_2_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_2_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class,
+        names = {"START_APPLICATION",
+            "EDIT_BAIL_APPLICATION",
+            "EDIT_BAIL_APPLICATION_AFTER_SUBMIT",
+            "MAKE_NEW_APPLICATION"})
+    void should_add_no_errors_when_email_and_telephone_and_mobile_selected(Event event) {
+
+        List<ContactPreference> listOfContactPreferences =
+            List.of(EMAIL, TELEPHONE, MOBILE);
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(bailCase);
+        when(callback.getPageId()).thenReturn(SUPPORTER_3_CONTACT_PREF_PAGE_ID);
+        when(bailCase.read(SUPPORTER_3_CONTACT_DETAILS))
+            .thenReturn(Optional.of(listOfContactPreferences));
+
+        PreSubmitCallbackResponse<BailCase> callbackResponse =
+            financialConditionSupporterContactPreferenceMidEventHandler
+                .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(0);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> financialConditionSupporterContactPreferenceMidEventHandler
+            .handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback_for_all_events() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getPageId()).thenReturn(SUPPORTER_1_CONTACT_PREF_PAGE_ID);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = financialConditionSupporterContactPreferenceMidEventHandler
+                    .canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.MID_EVENT
+                    && (callback.getEvent() == Event.START_APPLICATION
+                        || callback.getEvent() == Event.EDIT_BAIL_APPLICATION
+                        || callback.getEvent() == Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT
+                        || callback.getEvent() == Event.MAKE_NEW_APPLICATION)
+                    && callback.getPageId().equals(SUPPORTER_1_CONTACT_PREF_PAGE_ID)) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> financialConditionSupporterContactPreferenceMidEventHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> financialConditionSupporterContactPreferenceMidEventHandler
+            .canHandle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> financialConditionSupporterContactPreferenceMidEventHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> financialConditionSupporterContactPreferenceMidEventHandler
+            .handle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7949

### Change description ###

- MidEvent handler to add error validation when email or phone contact preferences are not checked for FCS 1-4 for Start Application, Edit Application (pre and post submit), Make an Application
- New Enum class for Contact Pref values
- New unit tests and functional tests for success and failure scenarios

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
