### PR TITLE
RIA-8311 Clearing isDetentionLocationCorrect after edit post submit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.0'
   id 'jacoco'
   id 'org.flywaydb.flyway' version '5.2.4'
-  id 'org.owasp.dependencycheck' version '8.2.1'
+  id 'org.owasp.dependencycheck' version '9.0.5'
   id 'org.sonarqube' version '3.0'
   id 'org.springframework.boot' version '2.7.14'
   id 'pmd'
@@ -205,7 +205,7 @@ jacocoTestReport {
 }
 
 pitest {
-  print('./gradlew --version'.execute().text.trim())
+//  print('./gradlew --version'.execute().text.trim())
   junit5PluginVersion = '1.1.2'
   targetClasses = ['uk.gov.hmcts.reform.bailcaseapi.*']
   excludedClasses = [

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -589,6 +589,9 @@ public enum BailCaseFieldDefinition {
     FCS_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS_4(
         "fcsInterpreterSignLanguageBookingStatus4", new TypeReference<InterpreterBookingStatus>(){}),
 
+    IS_DETENTION_LOCATION_CORRECT(
+        "isDetentionLocationCorrect", new TypeReference<YesOrNo>(){}),
+
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
@@ -79,6 +79,9 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
         final YesOrNo hasFinancialConditionSupporter4 = bailCase.read(
             HAS_FINANCIAL_COND_SUPPORTER_4, YesOrNo.class).orElse(NO);
 
+        final Optional<YesOrNo> optionalIsDetentionLocationCorrect = bailCase.read(IS_DETENTION_LOCATION_CORRECT, YesOrNo.class);
+
+
         if (optionalPreviousApplication.isPresent()) {
             String hasPreviousApplications = optionalPreviousApplication.get();
 
@@ -286,6 +289,10 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
                 sanitizeInterpreterLanguages(bailCase, FCS4_INTERPRETER_LANGUAGE_CATEGORY,
                                              FCS4_INTERPRETER_SIGN_LANGUAGE, FCS4_INTERPRETER_SPOKEN_LANGUAGE);
             }
+        }
+
+        if (callback.getEvent() == Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT && optionalIsDetentionLocationCorrect.isPresent()) {
+            bailCase.clear(IS_DETENTION_LOCATION_CORRECT);
         }
 
         return new PreSubmitCallbackResponse<>(bailCase);

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -16,7 +16,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(268, BailCaseFieldDefinition.values().length);
+        assertEquals(269, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
@@ -413,6 +413,16 @@ public class ApplicationDataRemoveHandlerTest {
         verify(bailCase, times(1)).remove(FCS4_INTERPRETER_SIGN_LANGUAGE);
     }
 
+    @Test
+    void should_clear_isDetentionLocationCorrect_if_present_for_edit_application_post_submit() {
+        when(bailCase.read(IS_DETENTION_LOCATION_CORRECT, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(callback.getEvent()).thenReturn(Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT);
+
+        applicationDataRemoveHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        verify(bailCase, times(1)).clear(IS_DETENTION_LOCATION_CORRECT);
+
+    }
+
     private void setUpValuesIfValuesAreRemoved() {
         when(bailCase.read(HAS_FINANCIAL_COND_SUPPORTER, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(bailCase.read(HAS_FINANCIAL_COND_SUPPORTER_2, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8311

### Change description ###

- Clearing isDetentionLocationCorrect after edit post submit when this value already exists to fix bug with wrong progress bar field showing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
