### PR TITLE
RIA-8311 Adding equals(NO) check before clearing detention location field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
@@ -291,9 +291,11 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
         }
 
         if (callback.getEvent() == Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT
-            && optionalIsDetentionLocationCorrect.get().equals(NO)) {
+            && optionalIsDetentionLocationCorrect.isPresent()) {
+            if (optionalIsDetentionLocationCorrect.get().equals(NO)) {
 
-            bailCase.clear(IS_DETENTION_LOCATION_CORRECT);
+                bailCase.clear(IS_DETENTION_LOCATION_CORRECT);
+            }
         }
 
         return new PreSubmitCallbackResponse<>(bailCase);

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
@@ -81,7 +81,6 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
 
         final Optional<YesOrNo> optionalIsDetentionLocationCorrect = bailCase.read(IS_DETENTION_LOCATION_CORRECT, YesOrNo.class);
 
-
         if (optionalPreviousApplication.isPresent()) {
             String hasPreviousApplications = optionalPreviousApplication.get();
 
@@ -291,7 +290,9 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
             }
         }
 
-        if (callback.getEvent() == Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT && optionalIsDetentionLocationCorrect.isPresent()) {
+        if (callback.getEvent() == Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT
+            && optionalIsDetentionLocationCorrect.get().equals(NO)) {
+
             bailCase.clear(IS_DETENTION_LOCATION_CORRECT);
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
@@ -415,9 +415,8 @@ public class ApplicationDataRemoveHandlerTest {
 
     @Test
     void should_clear_isDetentionLocationCorrect_if_present_for_edit_application_post_submit() {
-        when(bailCase.read(IS_DETENTION_LOCATION_CORRECT, YesOrNo.class)).thenReturn(Optional.of(YES));
         when(callback.getEvent()).thenReturn(Event.EDIT_BAIL_APPLICATION_AFTER_SUBMIT);
-
+        when(bailCase.read(IS_DETENTION_LOCATION_CORRECT, YesOrNo.class)).thenReturn(Optional.of(NO));
         applicationDataRemoveHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
         verify(bailCase, times(1)).clear(IS_DETENTION_LOCATION_CORRECT);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8311

### Change description ###

- Checking that IS_DETENTION_LOCATION_CORRECT = NO and then clearing the field. This is so that when IS_DETENTION_LOCATION_CORRECT = YES, it isn't cleared when the application is edited again

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
