### PR TITLE
RIA-8310 Allowing case flags to be created for FCS regardless of interpreter reqs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CreateFlagHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CreateFlagHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.bailcaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Slf4j
@@ -36,11 +37,11 @@ class CreateFlagHandler implements PreSubmitCallbackHandler<BailCase> {
         SUPPORTER_4_FAMILY_NAMES
     );
 
-    public static final List<BailCaseFieldDefinition> FCS_N_INTERPRETER_CATEGORY_FIELD = List.of(
-        FCS1_INTERPRETER_LANGUAGE_CATEGORY,
-        FCS2_INTERPRETER_LANGUAGE_CATEGORY,
-        FCS3_INTERPRETER_LANGUAGE_CATEGORY,
-        FCS4_INTERPRETER_LANGUAGE_CATEGORY
+    public static final List<BailCaseFieldDefinition> HAS_FINANCIAL_CONDITION_SUPPORTER_N = List.of(
+        HAS_FINANCIAL_COND_SUPPORTER,
+        HAS_FINANCIAL_COND_SUPPORTER_2,
+        HAS_FINANCIAL_COND_SUPPORTER_3,
+        HAS_FINANCIAL_COND_SUPPORTER_4
     );
 
     public static final List<BailCaseFieldDefinition> FCS_N_PARTY_ID_FIELD = List.of(
@@ -112,8 +113,8 @@ class CreateFlagHandler implements PreSubmitCallbackHandler<BailCase> {
 
         int i = 0;
         while (i < 4) {
-            Optional<List<String>> fcsInterpreterCategoryOptional = bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(i));
-            if (fcsInterpreterCategoryOptional.isPresent() && !fcsInterpreterCategoryOptional.get().isEmpty()) {
+            Optional<YesOrNo> hasFcsOptional = bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(i));
+            if (hasFcsOptional.isPresent()) {
                 int finalI = i;
                 String partyId = bailCase.read(FCS_N_PARTY_ID_FIELD.get(i), String.class).orElse(null);
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CreateFlagHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/CreateFlagHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.bailcaseapi.domain.entities.ccd.field.YesOrNo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -43,7 +44,7 @@ class CreateFlagHandlerTest {
     @Mock
     private BailCase bailCase;
     @Mock
-    List<String> listOfInterpreterLanguageCategory;
+    YesOrNo hasFcs;
     private CreateFlagHandler createFlagHandler;
     private final String partyId = "party-id";
     private final String appellantNameForDisplay = "some-name";
@@ -85,8 +86,8 @@ class CreateFlagHandlerTest {
     }
 
     @Test
-    void should_write_to_fcs_case_flag_fields_if_interpreter_language_category_present() {
-        when(bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(0))).thenReturn(Optional.of(listOfInterpreterLanguageCategory));
+    void should_write_to_fcs_case_flag_fields_if_has_fcs_field_present() {
+        when(bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(0))).thenReturn(Optional.of(hasFcs));
         when(bailCase.read(FCS_N_GIVEN_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsGivenName));
         when(bailCase.read(FCS_N_FAMILY_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsFamilyName));
 
@@ -98,7 +99,7 @@ class CreateFlagHandlerTest {
 
     @Test
     void should_write_empty_list_to_fcs_case_flag_fields_if_party_id_is_not_present() {
-        when(bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(0))).thenReturn(Optional.of(listOfInterpreterLanguageCategory));
+        when(bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(0))).thenReturn(Optional.of(hasFcs));
         when(bailCase.read(FCS_N_GIVEN_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsGivenName));
         when(bailCase.read(FCS_N_FAMILY_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsFamilyName));
         when(bailCase.read(FCS_N_PARTY_ID_FIELD.get(0), String.class)).thenReturn(Optional.empty());
@@ -115,7 +116,7 @@ class CreateFlagHandlerTest {
             new PartyFlagIdValue("party-id-existing", fcsCaseFlag));
 
         when(bailCase.read(FCS_LEVEL_FLAGS)).thenReturn(Optional.of(existLevelFlags));
-        when(bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(0))).thenReturn(Optional.of(listOfInterpreterLanguageCategory));
+        when(bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(0))).thenReturn(Optional.of(hasFcs));
         when(bailCase.read(FCS_N_GIVEN_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsGivenName));
         when(bailCase.read(FCS_N_FAMILY_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsFamilyName));
         when(bailCase.read(FCS_N_PARTY_ID_FIELD.get(0), String.class)).thenReturn(Optional.of("party-id-existing"));
@@ -177,7 +178,7 @@ class CreateFlagHandlerTest {
 
     @Test
     void should_throw_when_fcs_given_name_is_not_present() {
-        when(bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(0))).thenReturn(Optional.of(listOfInterpreterLanguageCategory));
+        when(bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(0))).thenReturn(Optional.of(hasFcs));
         when(bailCase.read(FCS_N_GIVEN_NAME_FIELD.get(0), String.class)).thenReturn(Optional.empty());
 
         assertThatThrownBy(
@@ -188,7 +189,7 @@ class CreateFlagHandlerTest {
 
     @Test
     void should_throw_when_fcs_family_name_is_not_present() {
-        when(bailCase.read(FCS_N_INTERPRETER_CATEGORY_FIELD.get(0))).thenReturn(Optional.of(listOfInterpreterLanguageCategory));
+        when(bailCase.read(HAS_FINANCIAL_CONDITION_SUPPORTER_N.get(0))).thenReturn(Optional.of(hasFcs));
         when(bailCase.read(FCS_N_GIVEN_NAME_FIELD.get(0), String.class)).thenReturn(Optional.of(fcsGivenName));
         when(bailCase.read(FCS_N_FAMILY_NAME_FIELD.get(0), String.class)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8310

### Change description ###

- Instead of reading from interpreter category fields for FCS, read HAS_FINANCIAL_COND_SUPPORTER fields which allows case flags to be created for each FCS on the case regardless of if there is an interpreter requirement or not
- This allows event 'Create flag' to show FCS as an option
- 'Manage flags' can then be used to modify any existing case flags

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
