### PR TITLE
RIA-8445 Defaulting fcsInterpreterYesNo to No when FCS are removed when editing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandler.java
@@ -218,7 +218,7 @@ public class ApplicationDataRemoveHandler implements PreSubmitCallbackHandler<Ba
             //Clear all the supporter 1-4 fields
             if (hasFinancialConditionSupporter1.equals(NO)) {
                 log.info("Clearing Financial Supporter details from bail application case data");
-
+                bailCase.write(FCS_INTERPRETER_YESNO, NO);
                 clearHasFinancialSupporter(bailCase, "");
                 clearHasFinancialSupporter(bailCase, "2");
                 clearHasFinancialSupporter(bailCase, "3");

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/handlers/presubmit/ApplicationDataRemoveHandlerTest.java
@@ -293,6 +293,13 @@ public class ApplicationDataRemoveHandlerTest {
     }
 
     @Test
+    void should_set_fcsInterpreterYesNo_to_no_when_fcs_removed() {
+        setUpValuesIfValuesAreRemoved();
+        applicationDataRemoveHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        verify(bailCase, times(1)).write(FCS_INTERPRETER_YESNO, NO);
+    }
+
+    @Test
     void should_not_remove_if_values_present() {
         setUpValuesIfValuesArePresent();
         applicationDataRemoveHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8445

### Change description ###

- Defaulting fcsInterpreterYesNo field to No when you edit an application pre or post submit to remove all FCS from the case. This screen won't show in the event so is still saving as Yes in the caseData and showing as yes in the Bail Application summary document. This resolves that issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
