### PR TITLE
RIA-8488 updated yarlswood to yarlsWood Hearing Centre

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/HearingCentre.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/HearingCentre.java
@@ -14,7 +14,7 @@ public enum HearingCentre {
     MANCHESTER("manchester"),
     NEWPORT("newport"),
     TAYLOR_HOUSE("taylorHouse"),
-    YARLSWOOD("yarlswood");
+    YARLSWOOD("yarlsWood");
 
     @JsonValue private final String value;
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/HearingCentreTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/HearingCentreTest.java
@@ -15,7 +15,7 @@ class HearingCentreTest {
         assertEquals("manchester", HearingCentre.MANCHESTER.toString());
         assertEquals("newport", HearingCentre.NEWPORT.toString());
         assertEquals("taylorHouse", HearingCentre.TAYLOR_HOUSE.toString());
-        assertEquals("yarlswood", HearingCentre.YARLSWOOD.toString());
+        assertEquals("yarlsWood", HearingCentre.YARLSWOOD.toString());
     }
 
     @Test
@@ -27,7 +27,7 @@ class HearingCentreTest {
         assertEquals(HearingCentre.MANCHESTER, HearingCentre.from("manchester").get());
         assertEquals(HearingCentre.NEWPORT, HearingCentre.from("newport").get());
         assertEquals(HearingCentre.TAYLOR_HOUSE, HearingCentre.from("taylorHouse").get());
-        assertEquals(HearingCentre.YARLSWOOD, HearingCentre.from("yarlswood").get());
+        assertEquals(HearingCentre.YARLSWOOD, HearingCentre.from("yarlsWood").get());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8488

### Change description ###

- Updated yarlswood to Yarlswood in HearingCentre class to match what is used in Hearings-api for appeals and bails hearings

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
