### PR TITLE
RIA-8420 Display hearing documents on previous applications screen

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinition.java
@@ -364,6 +364,8 @@ public enum BailCaseFieldDefinition {
         "decisionUnsignedDocument", new TypeReference<Document>(){}),
     TRIBUNAL_DOCUMENTS_WITH_METADATA(
         "tribunalDocumentsWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    HEARING_DOCUMENTS(
+        "hearingDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
     END_APPLICATION_DATE(
         "endApplicationDate", new TypeReference<String>(){}),
     END_APPLICATION_OUTCOME(

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTag.java
@@ -14,6 +14,7 @@ public enum DocumentTag {
     BAIL_SUBMISSION("bailSubmission"),
     B1_DOCUMENT("b1Document"),
     BAIL_END_APPLICATION("bailEndApplication"),
+    BAIL_NOTICE_OF_HEARING("bailNoticeOfHearing"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationService.java
@@ -40,12 +40,14 @@ public class ShowPreviousApplicationService {
             || previousBailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA).isPresent()
             || previousBailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA).isPresent()
             || previousBailCase.read(SIGNED_DECISION_DOCUMENTS_WITH_METADATA).isPresent()
+            || previousBailCase.read(HEARING_DOCUMENTS).isPresent()
         ) {
             return "|Documents||\n|--------|--------|\n"
                 + getApplicantDocumentsDetails(previousBailCase)
                 + getTribunalDocumentsDetails(previousBailCase)
                 + getHODocumentsDetails(previousBailCase)
-                + getDecisionDocumentsDetails(previousBailCase);
+                + getDecisionDocumentsDetails(previousBailCase)
+                + getHearingDocumentsDetails(previousBailCase);
         }
         return null;
     }
@@ -622,6 +624,13 @@ public class ShowPreviousApplicationService {
             .read(TRIBUNAL_DOCUMENTS_WITH_METADATA);
         return mayBeTribunalDocs.isEmpty()
             ? "" : getDetailsForGivenCollection(mayBeTribunalDocs, "Tribunal") + "|\n";
+    }
+
+    private String getHearingDocumentsDetails(BailCase previousBailCase) {
+        Optional<List<IdValue<DocumentWithMetadata>>> mayBeHearingDocs = previousBailCase
+            .read(HEARING_DOCUMENTS);
+        return mayBeHearingDocs.isEmpty()
+            ? "" : getDetailsForGivenCollection(mayBeHearingDocs, "Hearing") + "|\n";
     }
 
     private String getDecisionDocumentsDetails(BailCase previousBailCase) {

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -16,7 +16,7 @@ public class BailCaseFieldDefinitionTest {
      */
     @Test
     void fail_if_changes_needed_after_modifying_bail_case_definition() {
-        assertEquals(272, BailCaseFieldDefinition.values().length);
+        assertEquals(273, BailCaseFieldDefinition.values().length);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/entities/DocumentTagTest.java
@@ -18,13 +18,14 @@ public class DocumentTagTest {
         assertEquals("bailSubmission", DocumentTag.BAIL_SUBMISSION.toString());
         assertEquals("b1Document", DocumentTag.B1_DOCUMENT.toString());
         assertEquals("bailEndApplication", DocumentTag.BAIL_END_APPLICATION.toString());
+        assertEquals("bailNoticeOfHearing", DocumentTag.BAIL_NOTICE_OF_HEARING.toString());
         assertEquals("", DocumentTag.NONE.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(10, DocumentTag.values().length);
+        assertEquals(11, DocumentTag.values().length);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationServiceTest.java
@@ -70,6 +70,9 @@ public class ShowPreviousApplicationServiceTest {
         List<IdValue<DocumentWithMetadata>> existingDecisionDocuments = List.of(
             new IdValue<>("1", document1WithMetadata)
         );
+        List<IdValue<DocumentWithMetadata>> existingHearingDocuments = List.of(
+            new IdValue<>("1", document2WithMetadata)
+        );
 
 
         List<IdValue<Direction>> existingDirections =
@@ -131,6 +134,8 @@ public class ShowPreviousApplicationServiceTest {
             .thenReturn(Optional.of(existingApplicantDocuments));
         when(bailCase.read(TRIBUNAL_DOCUMENTS_WITH_METADATA))
             .thenReturn(Optional.of(existingTribunalDocuments));
+        when(bailCase.read(HEARING_DOCUMENTS))
+            .thenReturn(Optional.of(existingHearingDocuments));
         when(bailCase.read(HOME_OFFICE_DOCUMENTS_WITH_METADATA))
             .thenReturn(Optional.of(existingHODocuments));
         when(bailCase.read(SIGNED_DECISION_DOCUMENTS_WITH_METADATA))
@@ -292,6 +297,9 @@ public class ShowPreviousApplicationServiceTest {
         assertTrue(label.contains(
             "|Decision document 1<br>*Document:* <a href=\"/documents/document1BinaryUrl\" "
                 + "target=\"_blank\">document1FileName</a>"));
+        assertTrue(label.contains(
+            "|Hearing document 1<br>*Document:* <a href=\"/documents/document2BinaryUrl\" "
+            + "target=\"_blank\">document2FileName</a>"));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8420

### Change description ###

- Adding hearing documents field to ia-bail-case-api then displaying them on the screen for View Previous Applications
- Document link also available to open in browser

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
