### PR TITLE
RIA-8507 Fix bug for previous applications with optional FCS passport number

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationService.java
@@ -355,13 +355,16 @@ public class ShowPreviousApplicationService {
                 .append("|\n");
 
             stringBuilder.append("|Passport number|")
-                .append(previousBailCase.read(supporterHasPassport).orElse(YesOrNo.NO))
+                .append(previousBailCase.read(supporterHasPassport, YesOrNo.class).orElse(YesOrNo.NO))
                 .append("|\n");
 
-            if (previousBailCase.read(supporterHasPassport).orElse(YesOrNo.NO).equals("Yes")) {
+            Optional<String> mayBeSupporterPassportNumber = previousBailCase.read(supporterPassport);
+
+            if (previousBailCase.read(supporterHasPassport, YesOrNo.class).orElse(YesOrNo.NO).equals(YesOrNo.YES)
+                && mayBeSupporterPassportNumber.isPresent()) {
                 stringBuilder.append("|Passport number|")
                     .append(previousBailCase.read(supporterPassport)
-                                .orElseThrow(getErrorThrowable(supporterPassport)))
+                        .orElseThrow(getErrorThrowable(supporterPassport)))
                     .append("|\n");
             }
 

--- a/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bailcaseapi/domain/service/ShowPreviousApplicationServiceTest.java
@@ -446,7 +446,8 @@ public class ShowPreviousApplicationServiceTest {
                 + "|Occupation|Doctor|\n"
                 + "|Immigration status|Resident|\n"
                 + "|Nationalities|American|\n"
-                + "|Passport number|No|\n"
+                + "|Passport number|Yes|\n"
+                + "|Passport number|P12345|\n"
                 + "|Spoken language Interpreter|lang 1|\n"
                 + "|Financial condition amount (£)|3000|"
         ));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-8507

### Change description ###

- FCS passport number is an optional CCD field, so checking it's present before appending to label in previous applications
- This allows you to view previous applications as mid event will not throw exception when it's missing
- Updated unit test 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
